### PR TITLE
Use CONDA_PREFIX, not CONDA_ENV_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 script:
   - python setup.py develop
-  - python -m nb_conda_kernels.install --enable --prefix="${CONDA_ENV_PATH}"
+  - python -m nb_conda_kernels.install --enable --sys-prefix
   - npm run test
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ conda install -c conda-forge nb_conda_kernels
 You'll need conda installed, either from [Anaconda](https://www.continuum.io/downloads) or [miniconda](http://conda.pydata.org/miniconda.html). You can create a Python development environment named `nb_conda_kernels` from `./environment.yml`.
 
 ```shell
-conda create -n nb_conda_kernels python=YOUR_FAVORITE_PYTHON
-conda update env
+conda env update
 source activate nb_conda_kernels
 python setup.py develop
-python -m nb_conda_kernels.install --enable --prefix="${CONDA_ENV_PATH}"
+python -m nb_conda_kernels.install --enable --sys-prefix
 ```
 
 We _still_ use `npm` for testing things, so then run:
@@ -36,6 +35,10 @@ npm run test
 
 
 ## Changelog
+
+### 2.0.0
+- use kernel metadata for storing environment information
+- use new `CONDA_PREFIX` throughout
 
 ### 1.0.3
 - ignore build cleanup on windows due to poorly-behaved PhantomJS processes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,5 +69,5 @@ build: off
 
 test_script:
     - cmd: python setup.py develop
-    - cmd: python -m nb_conda_kernels.install --enable --prefix="%CONDA_DEFAULT_ENV%"
+    - cmd: python -m nb_conda_kernels.install --enable --sys-prefix
     - cmd: npm run test

--- a/nb_conda_kernels/install.py
+++ b/nb_conda_kernels/install.py
@@ -36,12 +36,12 @@ parser.add_argument(
 
 parser.add_argument(
     "--user",
-    help="use HOME/.jupyter to update nb_user_sessions config",
+    help="use HOME/.jupyter to update nb_conda_kernels config",
     action="store_true",
     default=False)
 parser.add_argument(
     "--sys-prefix",
-    help="use sys.prefix to update nb_user_sessions config",
+    help="use sys.prefix to update nb_conda_kernels config",
     action="store_true",
     default=False)
 


### PR DESCRIPTION
Conda 4.1.x now uses `CONDA_PREFIX`, not `CONDA_ENV_PATH` (which didn't work on windows).

This is mainly a documentation and testing fix, etc. as the builds all use `PREFIX`.