### PR TITLE
Do not add twice the same python

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -87,8 +87,10 @@ class CondaKernelSpecManager(KernelSpecManager):
                     env_name = split(base)[1]
                     name = 'conda-env-{}-{}'.format(env_name, language_key)
                     language_envs[name] = {
-                        'display_name': '{} [conda env:{}]'.format(
+                        'display_name': '{} [conda:{}]'.format(
                             display_prefix, env_name),
+                        'env_name': env_name,
+                        'display_prefix': display_prefix,
                         'executable': exe_path,
                         'language_key': language_key,
                     }
@@ -108,25 +110,32 @@ class CondaKernelSpecManager(KernelSpecManager):
 
         # We also add the root prefix into the soup
         root_prefix = join(self._conda_info["root_prefix"], jupyter)
+        root_python_exec = None
         if exists(root_prefix):
+            root_python_exec = abspath(join(self._conda_info["root_prefix"],
+                                            python))
             all_envs.update({
                 'conda-root-py': {
                     'display_name': 'Python [conda root]',
-                    'executable': join(self._conda_info["root_prefix"],
-                                       python),
+                    'env_name': 'root',
+                    'display_prefix': 'Python',
+                    'executable': root_python_exec,
                     'language_key': 'py',
                 }
             })
         # Use Jupyter's default kernel name ('python2' or 'python3') for
         # current env
-        if exists(join(sys.prefix, jupyter)) and exists(join(sys.prefix,
-                                                             python)):
-            all_envs.update({
-                NATIVE_KERNEL_NAME: {
-                    'display_name': 'Python [default]',
-                    'executable': join(sys.prefix, python),
-                    'language_key': 'py',
-                }
+        default_python_exec = abspath(join(sys.prefix, python))
+        if exists(join(sys.prefix, jupyter)) and exists(default_python_exec):
+            if root_python_exec and root_python_exec != default_python_exec:
+                all_envs.update({
+                    NATIVE_KERNEL_NAME: {
+                        'display_name': 'Python [default]',
+                        'env_name': 'default', 
+                        'display_prefix': 'Python',
+                        'executable': default_python_exec,
+                        'language_key': 'py',
+                    }
             })
 
         return all_envs


### PR DESCRIPTION
if default and root points to the same executable, don't add twice, only keep the `root`.

also rename `Python [conda env:mycondaenv]` to  `Python [conda:mycondaenv]`.
Root is still `Python [conda root]` and default is still `Python [default]`. The presence of the `:` allow to differentiate if there is a `root` environment.

I also plan to let users define their own naming pattern.