### PR TITLE
Add option to add environment variables to python kernels

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -6,7 +6,7 @@ import sys
 import time
 
 from os.path import exists, join, split, dirname, abspath
-from traitlets import Unicode
+from traitlets import Unicode, Dict
 
 from jupyter_client.kernelspec import (
     KernelSpecManager,
@@ -23,6 +23,8 @@ class CondaKernelSpecManager(KernelSpecManager):
     """
     env_filter = Unicode(None, config=True, allow_none=True,
                          help="Do not list environment names that match this regex")
+    python_kernel_env = Dict(None, config=True, allow_none=True,
+                             help="Environment variables for python kernels")
 
     def __init__(self, **kwargs):
         super(CondaKernelSpecManager, self).__init__(**kwargs)
@@ -191,7 +193,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                              "{connection_file}"],
                     "display_name": display_name,
                     "language": "python",
-                    "env": {},
+                    "env": self.python_kernel_env or {},
                     "resource_dir": join(dirname(abspath(__file__)), "logos",
                                          "python")
                  }


### PR DESCRIPTION
It would be very useful to be able to specify custom environment variables for python kernels 