### PR TITLE
Add conda 4.4 support; move to conda-based testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ target/
 node_modules/
 screenshots/
 *.xunit.xml
+
+# npm
+package-lock.json
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - PYTHON_VERSION=2.7
   - PYTHON_VERSION=3.5
   - PYTHON_VERSION=3.6
+  - PYTHON_VERSION=3.6 CONDA_4_4_STYLE=Yes
   - PYTHON_VERSION=3.6 CONDA_SPEC='=4.3'
 
 install:
@@ -20,7 +21,12 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   # Fix the conda version before full activation
   - $HOME/miniconda/bin/conda install conda$CONDA_SPEC --yes
-  - source $HOME/miniconda/bin/activate
+  - if [ "$CONDA_4_4_STYLE" == "yes" ]; then
+        . $HOME/miniconda/etc/profile.d/conda.sh;
+        conda activate;
+    else
+        source $HOME/miniconda/bin/activate;
+    fi
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
   # So we can get python-coveralls
   - conda config --append channels conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ os:
   - osx
 
 env:
-  - PYTHON_VERSION=2.7 CONDA_VERSION=4.5
-  - PYTHON_VERSION=3.5 CONDA_VERSION=4.5
-  - PYTHON_VERSION=3.6 CONDA_VERSION=4.5
-  - PYTHON_VERSION=3.6 CONDA_VERSION=4.3
+  - PYTHON_VERSION=2.7
+  - PYTHON_VERSION=3.5
+  - PYTHON_VERSION=3.6
+  - PYTHON_VERSION=3.6 CONDA_SPEC='=4.3'
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -18,13 +18,14 @@ install:
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - $HOME/miniconda/bin/conda install conda=$CONDA_VERSION --yes
+  # Fix the conda version before full activation
+  - $HOME/miniconda/bin/conda install conda$CONDA_SPEC --yes
   - source $HOME/miniconda/bin/activate
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
   # So we can get python-coveralls
   - conda config --append channels conda-forge
   # The tests need to see the Python kernel in the root environment
-  - conda install conda-build anaconda-client ipykernel python-coveralls
+  - conda install conda-build ipykernel python-coveralls
   # The tests also need to see an R kernel in another environment. And
   # the current implementation requires jupyter to be there as well.
   - conda create -n test_env r-irkernel r-base jupyter_core

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # The tests need to see the Python kernel in the root environment
   - conda install conda-build anaconda-client ipykernel python-coveralls
   # The tests also need to see an R kernel in another environment
-  - conda create -n test_env r-irkernel r-base ipykernel
+  - conda create -n test_env r-irkernel r-base
   - conda info -a
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,17 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update --yes --quiet conda
-  - conda install -n root conda conda-env anaconda-client notebook
+  - conda update conda
+  # So we can get python-coveralls
+  - conda config --append channels conda-forge
+  # The tests need to see the Python kernel in the root environment
+  - conda install conda-build anaconda-client ipykernel python-coveralls
+  # The tests also need to see an R kernel in another environment
+  - conda create -n test_env r-irkernel r-base ipykernel
   - conda info -a
-  - conda create -n nb_conda_kernels python=$TRAVIS_PYTHON_VERSION
-  - conda install -n nb_conda_kernels -c conda-forge --file requirements.txt
-  - source activate nb_conda_kernels
-  - pip install python-coveralls
-  - npm install
-  - conda list
-  - npm list
 
 script:
-  - pip install -e .
-  - python -m nb_conda_kernels.install --enable --prefix="${CONDA_PREFIX}"
-  - npm run test
+  - conda build conda-recipe
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,37 @@
-language: python
+language: generic
+sudo: false
 
-sudo: true
+os:
+  - linux
+  - osx
 
-branches:
-  only:
-    - master
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - libstdc++-4.9-dev
-
-python:
-  # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
-  - "3.5"
-  - "3.6"
+env:
+  - PYTHON_VERSION=2.7 CONDA_VERSION=4.5
+  - PYTHON_VERSION=3.5 CONDA_VERSION=4.5
+  - PYTHON_VERSION=3.6 CONDA_VERSION=4.5
+  - PYTHON_VERSION=3.6 CONDA_VERSION=4.3
 
 install:
-  - sudo apt-get update
-  - sudo apt-get install -y libfreetype6-dev libfontconfig1-dev
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
+  - $HOME/miniconda/bin/conda install conda=$CONDA_VERSION --yes
+  - source $HOME/miniconda/bin/activate
   - conda config --set always_yes yes --set changeps1 no
-  - conda update conda
   # So we can get python-coveralls
   - conda config --append channels conda-forge
   # The tests need to see the Python kernel in the root environment
   - conda install conda-build anaconda-client ipykernel python-coveralls
-  # The tests also need to see an R kernel in another environment
-  - conda create -n test_env r-irkernel r-base
+  # The tests also need to see an R kernel in another environment. And
+  # the current implementation requires jupyter to be there as well.
+  - conda create -n test_env r-irkernel r-base jupyter_core
   - conda info -a
 
 script:
-  - conda build conda-recipe
+  - conda build conda-recipe --python=$PYTHON_VERSION
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -7,21 +7,26 @@ notebook, you can choose a kernel corresponding to the environment
 you wish to run within. This will allow you to have different versions
 of python, libraries, etc. for different notebooks.
 
-**Important Note** : To use a conda environment as a kernel, don't forget to install `ipykernel` in this environment or it won't show up in the kernel list.
+**Important Note** : To use a Python kernel from a conda environment,
+don't forget to install `ipykernel` in that environment or it won't
+show up on the kernel list. Similary, to use an R kernel, install
+`r-irkernel`.
 
 ## Installation
 ```shell
-conda install -c conda-forge nb_conda_kernels
+conda install nb_conda_kernels
 ```
-
 
 ### Getting Started
 You'll need conda installed, either from [Anaconda](https://www.continuum.io/downloads) or [miniconda](http://conda.pydata.org/miniconda.html). 
 
 ```shell
-conda create -n nb_conda_kernels python=YOUR_FAVORITE_PYTHON
-conda install -n nb_conda_kernels --file requirements.txt -c r
-source activate nb_conda_kernels
+conda create -n nb_conda_kernels nb_conda_kernels python=YOUR_FAVORITE_PYTHON
+conda activate nb_conda_kernels
+# Remove just the package, leave the dependencies
+conda remove nb_conda_kernels --force
+# Install the test packages
+conda install --file requirements.txt
 python setup.py develop
 python -m nb_conda_kernels.install --enable --prefix="${CONDA_PREFIX}"
 # or on windows
@@ -37,9 +42,21 @@ Finally, you are ready to run the tests!
 ```shell
 npm run test
 ```
-
+Note that the tests assume the existence of `ipykernel` in the
+base/root conda environment:
+```shell
+conda install -n root ipykernel
+```
+In addition, there needs to be at least one conda environment
+with the `R` kernel, and it need not be root;
+```shell
+conda create -n nbrtest r-irkernel
+```
 
 ## Changelog
+
+### 2.1.1
+- move to a full conda-based approach to build and test
 
 ### 2.1.0
 - add support for regex-based filtering of conda environments that should not appear in the list

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ conda create -n nbrtest r-irkernel
 
 ### 2.1.1
 - move to a full conda-based approach to build and test
+- add support for conda 4.4 and later, which can remove `conda` from the PATH
 
 ### 2.1.0
 - add support for regex-based filtering of conda environments that should not appear in the list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,23 +53,18 @@ install:
           else
             {$root = "C:\Miniconda-x64"}
           $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda config --set always_yes yes --set changeps1 no
-    - cmd: conda install -n root conda conda-env anaconda-client notebook
+    - cmd: conda update conda
+    # The tests need to see a Python kernel in the root environment
+    - cmd: conda install conda-build anaconda-client ipykernel
+    # The tests also need to see an R kernel in another environment
+    - cmd: conda create -n test_env r-irkernel r-base ipykernel
     - cmd: set PYTHONUNBUFFERED=1
     - cmd: conda info -a
-    - cmd: conda create -n nb_conda_kernels "%PY_CONDITION%"
-    - cmd: conda install -n nb_conda_kernels -c conda-forge --file requirements.txt
-    - cmd: activate nb_conda_kernels
-    - cmd: npm install
-    - cmd: conda list
-    - cmd: npm list
 
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - cmd: pip install -e .
-    - cmd: python -m nb_conda_kernels.install --enable --prefix="%CONDA_PREFIX%"
-    - cmd: npm run test
+    - cmd: conda build conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
     # The tests need to see a Python kernel in the root environment
     - cmd: conda install conda-build anaconda-client ipykernel
     # The tests also need to see an R kernel in another environment
-    - cmd: conda create -n test_env r-irkernel r-base ipykernel
+    - cmd: conda create -n test_env r-irkernel r-base
     - cmd: set PYTHONUNBUFFERED=1
     - cmd: conda info -a
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "2.1.0" %}
+{% set gh_org = "Anaconda-Platform" %}
+{% set gh_repo = "nb_conda_kernels" %}
+
+package:
+  name: {{ gh_repo }}
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  number: 0
+  script:
+    - python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - jupyter_client >=4.2
+
+test:
+  imports:
+    - nb_conda_kernels
+
+about:
+  home: https://github.com/{{ gh_org }}/{{ gh_repo }}
+  license: BSD 3-Clause
+  license_file: LICENSE
+  summary: 'Launch Jupyter kernels for any installed conda environment.'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ test:
   source_files:
     - package.json
   requires:
-    - anaconda-client
     - coverage
     - flake8
     - mock

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,8 +21,17 @@ requirements:
     - jupyter_client >=4.2
 
 test:
-  imports:
-    - nb_conda_kernels
+  source_files:
+    - package.json
+  requires:
+    - anaconda-client
+    - coverage
+    - flake8
+    - mock
+    - nodejs
+    - nose
+    - notebook
+    - r-irkernel
 
 about:
   home: https://github.com/Anaconda-Platform/nb_conda_kernels

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,8 @@
-{% set version = "2.1.0" %}
-{% set gh_org = "Anaconda-Platform" %}
-{% set gh_repo = "nb_conda_kernels" %}
+{% set data = load_setup_py_data() %}
 
 package:
-  name: {{ gh_repo }}
-  version: {{ version }}
+  name: nb_conda_kernels
+  version: {{ data.get('version') }}
 
 source:
   path: ../
@@ -27,7 +25,7 @@ test:
     - nb_conda_kernels
 
 about:
-  home: https://github.com/{{ gh_org }}/{{ gh_repo }}
+  home: https://github.com/Anaconda-Platform/nb_conda_kernels
   license: BSD 3-Clause
   license_file: LICENSE
   summary: 'Launch Jupyter kernels for any installed conda environment.'

--- a/conda-recipe/post-link.bat
+++ b/conda-recipe/post-link.bat
@@ -1,0 +1,4 @@
+@echo off
+(
+  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -1,0 +1,3 @@
+{
+  "${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix="${PREFIX}"
+} >>"$PREFIX/.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.bat
+++ b/conda-recipe/pre-unlink.bat
@@ -1,0 +1,4 @@
+@echo off
+(
+  "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -1,0 +1,3 @@
+{
+  "${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix="${PREFIX}"
+} >>"$PREFIX/.messages.txt" 2>&1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,0 +1,2 @@
+npm install
+npm run test

--- a/conda-recipe/run_test.py
+++ b/conda-recipe/run_test.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import json
 from subprocess import call
 from nb_conda_kernels import CondaKernelSpecManager
 
@@ -16,61 +14,61 @@ from nb_conda_kernels import CondaKernelSpecManager
 spec_manager = CondaKernelSpecManager()
 conda_info = spec_manager._conda_info
 if conda_info is None:
-	print('Cannot find conda, skipping tests.')
-	exit(-1)
+    print('Cannot find conda, skipping tests.')
+    exit(-1)
 print('Current prefix: {}'.format(sys.prefix))
 print('Root prefix: {}'.format(conda_info['root_prefix']))
 print('Environments:')
 for env in conda_info['envs']:
-	print('  - {}'.format(env))
+    print('  - {}'.format(env))
 print('Kernels included in _all_envs:')
 for key, value in spec_manager._all_envs().items():
-	print('  - {}: {}'.format(key, value['executable']))
+    print('  - {}: {}'.format(key, value['executable']))
 checks = {}
 print('Kernels included in get_all_specs:')
 for key, value in spec_manager.get_all_specs().items():
-	print('  - {}: {}'.format(key, value['spec']['argv'][0]))
-	key = key.lower()
-	if key.startswith('python'):
-		checks['default_py'] = True
-	if key.startswith('ir'):
-		checks['default_r'] = True
-	if key.startswith('conda-root-py'):
-		checks['root_py'] = True
-	if key.startswith('conda-env-'):
-		if key.endswith('-py'):
-			checks['env_py'] = True
-		if key.endswith('-r'):
-			checks['env_r'] = True
+    print('  - {}: {}'.format(key, value['spec']['argv'][0]))
+    key = key.lower()
+    if key.startswith('python'):
+        checks['default_py'] = True
+    if key.startswith('ir'):
+        checks['default_r'] = True
+    if key.startswith('conda-root-py'):
+        checks['root_py'] = True
+    if key.startswith('conda-env-'):
+        if key.endswith('-py'):
+            checks['env_py'] = True
+        if key.endswith('-r'):
+            checks['env_r'] = True
 if len(checks) < 5:
-	print('ERROR: the environment is not properly configured for testing:')
-	if not checks.get('default_py'):
-		print('  - Default Python kernel missing')
-	if not checks.get('default_r'):
-		print('  - Default R kernel missing')
-	if not checks.get('root_py'):
-		print('  - Root Python kernel missing')
-	if not checks.get('env_py'):
-		print('  - Environment Python kernel missing')
-	if not checks.get('env_r'):
-		print('  - Environment R kernel missing')
-	print('Skipping NPM tests, since they will fail.')
-	exit(-1)
+    print('ERROR: the environment is not properly configured for testing:')
+    if not checks.get('default_py'):
+        print('  - Default Python kernel missing')
+    if not checks.get('default_r'):
+        print('  - Default R kernel missing')
+    if not checks.get('root_py'):
+        print('  - Root Python kernel missing')
+    if not checks.get('env_py'):
+        print('  - Environment Python kernel missing')
+    if not checks.get('env_r'):
+        print('  - Environment R kernel missing')
+    print('The NPM tests are certain to fail because of this.')
+    # exit(-1)
 
 npm_cmd = ['npm']
 if sys.platform.startswith('win'):
-	npm_cmd = ['cmd.exe', '/c'] + npm_cmd
+    npm_cmd = ['cmd.exe', '/c'] + npm_cmd
 
 print('Installing NPM test packages:')
 command = npm_cmd + ['install']
 print('Calling: {}'.format(' '.join(command)))
 status = call(command)
 if status:
-	exit(status)
+    exit(status)
 
 print('Running NPM tests:')
 command = npm_cmd + ['run', 'test']
 print('Calling: {}'.format(' '.join(command)))
 status = call(command)
 if status:
-	exit(status)
+    exit(status)

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+python -c "import json
+from nb_conda_kernels import CondaKernelSpecManager as CKSM
+sm = CKSM()
+print(json.dumps(sm._conda_info, indent=2))
+print(json.dumps(sm.get_all_specs(), indent=2))"
+npm install
+npm run test

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
+# This is for diagnostic purposes only.
+python -c "import json
+from nb_conda_kernels import CondaKernelSpecManager as CKSM
+sm = CKSM()
+print(json.dumps(sm._conda_info, indent=2))
+print(json.dumps(sm.get_all_specs(), indent=2))"
 npm install
 npm run test

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,8 +1,3 @@
 #!/bin/sh
-python -c "import json
-from nb_conda_kernels import CondaKernelSpecManager as CKSM
-sm = CKSM()
-print(json.dumps(sm._conda_info, indent=2))
-print(json.dumps(sm.get_all_specs(), indent=2))"
 npm install
 npm run test

--- a/nb_conda_kernels/_version.py
+++ b/nb_conda_kernels/_version.py
@@ -1,2 +1,2 @@
-version_info = (2, 1, 0)
+version_info = (2, 1, 1)
 __version__ = '.'.join(map(str, version_info))

--- a/nb_conda_kernels/install.py
+++ b/nb_conda_kernels/install.py
@@ -43,7 +43,8 @@ CKSM = "nb_conda_kernels.CondaKernelSpecManager"
 KSMC = "kernel_spec_manager_class"
 
 
-def pretty(it): return json.dumps(it, indent=2)
+def pretty(it):
+    return json.dumps(it, indent=2)
 
 
 def install(enable=False, disable=False, prefix=None, verbose=False):

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 
+import os
 from os.path import exists, join, split, dirname, abspath
 from traitlets import Unicode
 
@@ -15,6 +16,8 @@ from jupyter_client.kernelspec import (
 )
 
 CACHE_TIMEOUT = 60
+
+CONDA_EXE = os.environ.get("CONDA_EXE", "conda")
 
 
 class CondaKernelSpecManager(KernelSpecManager):
@@ -52,7 +55,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         if expiry is None or expiry < time.time():
             self.log.debug("[nb_conda_kernels] refreshing conda info")
             try:
-                p = subprocess.check_output(["conda", "info", "--json"]
+                p = subprocess.check_output([CONDA_EXE, "info", "--json"]
                                             ).decode("utf-8")
                 conda_info = json.loads(p)
             except Exception as err:
@@ -167,10 +170,8 @@ class CondaKernelSpecManager(KernelSpecManager):
         if self._conda_info is None:
             return {}
 
-        if (
-            self._conda_kernels_cache_expiry is None or
-            self._conda_kernels_cache_expiry < time.time()
-           ):
+        if (self._conda_kernels_cache_expiry is None or
+            self._conda_kernels_cache_expiry < time.time()):
             self.log.debug("[nb_conda_kernels] refreshing conda kernelspecs")
             self._conda_kernels_cache = self._load_conda_kspecs()
             self._conda_kernels_cache_expiry = time.time() + CACHE_TIMEOUT
@@ -194,7 +195,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                     "env": {},
                     "resource_dir": join(dirname(abspath(__file__)), "logos",
                                          "python")
-                 }
+                }
             elif info['language_key'] == 'r':
                 kspec = {
                     "argv": [executable, "--slave", "-e", "IRkernel::main()",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "python -m nose nb_conda_kernels.tests",
-    "lint": "npm run lint && flake8 setup.py nb_conda_kernels"
+    "lint": "flake8 setup.py nb_conda_kernels"
   },
   "repository": {
     "type": "git",

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,7 @@ verbosity=1
 detailed-errors=1
 with-coverage=1
 cover-package=nb_conda_kernels
+
+[flake8]
+ignore=E501,E129,E722
+


### PR DESCRIPTION
Currently conda-forge is being used to build things. There's nothing wrong with that _per se_. But because the conda package requires post-link and pre-unlink scripts to work properly, they should be part of the source, and included here.

To that end I've pulled those scripts over and a basic conda recipe that builds the package locally. Nothing has been changed w.r.t. the current AppVeyor/Travis builds, but in theory, these should be building and testing the conda packages to fully vet the post-link/pre-unlink scripts.

Future work:
- More testing in the conda build process itself
- Modify appveyor and travis scripts to use the recipe

