### PR TITLE
Test 'new-style' (conda 4.4+) installs against conda 4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ python:
   - "3.5"
   - "3.6"
 
+env:
+  # test new (conda>=4.4) and old-style conda installs
+  - CONDA_4_4_STYLE=false
+  - CONDA_4_4_STYLE=true
+
 install:
   - sudo apt-get update
   - sudo apt-get install -y libfreetype6-dev libfontconfig1-dev
@@ -28,15 +33,24 @@ install:
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - if [ "$CONDA_4_4_STYLE" = "true" ]; then
+      . $HOME/miniconda/etc/profile.d/conda.sh
+    else
+      export PATH="$HOME/miniconda/bin:$PATH"
+    fi
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update --yes --quiet conda
-  - conda install -n root conda conda-env anaconda-client notebook
+  # get 4.6 from canary (can revert to 'conda' when released)
+  - conda install -n root conda-canary::conda=4.6 conda-env anaconda-client notebook
   - conda info -a
   - conda create -n nb_conda_kernels python=$TRAVIS_PYTHON_VERSION
   - conda install -n nb_conda_kernels -c conda-forge --file requirements.txt
-  - source activate nb_conda_kernels
+  - if [ "$CONDA_4_4_STYLE" = true ]; then
+      conda activate nb_conda_kernels
+    else
+      source activate nb_conda_kernels
+    fi
   - pip install python-coveralls
   - npm install
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ install:
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - if [ "$CONDA_4_4_STYLE" = "true" ]; then
-      . $HOME/miniconda/etc/profile.d/conda.sh
+      . $HOME/miniconda/etc/profile.d/conda.sh;
     else
-      export PATH="$HOME/miniconda/bin:$PATH"
+      export PATH="$HOME/miniconda/bin:$PATH";
     fi
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
@@ -47,9 +47,9 @@ install:
   - conda create -n nb_conda_kernels python=$TRAVIS_PYTHON_VERSION
   - conda install -n nb_conda_kernels -c conda-forge --file requirements.txt
   - if [ "$CONDA_4_4_STYLE" = true ]; then
-      conda activate nb_conda_kernels
+      conda activate nb_conda_kernels;
     else
-      source activate nb_conda_kernels
+      source activate nb_conda_kernels;
     fi
   - pip install python-coveralls
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - if [ "$CONDA_4_4_STYLE" = "true" ]; then
+- if [ "$CONDA_4_4_STYLE" = "true" ]; then
       . $HOME/miniconda/etc/profile.d/conda.sh;
     else
       export PATH="$HOME/miniconda/bin:$PATH";
@@ -41,8 +41,13 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update --yes --quiet conda
-  # get 4.6 from canary (can revert to 'conda' when released)
-  - conda install -n root conda-canary::conda=4.6 conda-env anaconda-client notebook
+  # test new-style installs against conda 4.6 (from conda-canary if necessary)
+  - if [ "$CONDA_4_4_STYLE" = "true" ]; then
+      conda config --append channels conda-canary;
+      conda install -n base conda=4.6 conda-env anaconda-client notebook;
+    else
+      conda install -n root conda conda-env anaconda-client notebook;
+    fi
   - conda info -a
   - conda create -n nb_conda_kernels python=$TRAVIS_PYTHON_VERSION
   - conda install -n nb_conda_kernels -c conda-forge --file requirements.txt


### PR DESCRIPTION
nb_conda_kernels currently doesn't support 'new'-style conda installs (https://www.anaconda.com/blog/developer-blog/how-to-get-ready-for-the-release-of-conda-4-4/), but see #79 for a proposed fix. 

This PR sets up Travis to test *both* old- and new-style installs, since both of these need to be supported in the future.

For now this testing is running against conda 4.6 from conda-canary following @kalefranz suggestion (at https://github.com/Anaconda-Platform/anaconda-nb-extensions/issues/168#issuecomment-392280875 ) to wait until 4.6, since some aspects of the new install regime were still being worked out in 4.4 and 4.5, and the old-style install is still the default for the latest installers: 
>Once we release conda 4.6, I think we’ll have most of the changes in this regard complete, after a lot of tuning and tweaking based on feedback from users interacting with this in the wild. I would wait to target any change toward conda 4.6+.

A similar set of changes should be done for Windows/Appveyor, but is not yet included here.
