### PR TITLE
Update the _skip_env to only deal with the env name

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -90,7 +90,8 @@ class CondaKernelSpecManager(KernelSpecManager):
         """
         if self.env_filter is None:
             return False
-        return self._env_filter_regex.search(path) is not None
+        # sometimes deal with the full path will cause some problem, e.g. the user name is the same as the env name.
+        return self._env_filter_regex.search(split(path)[1]) is not None
 
     def _all_envs(self):
         """ Find the all the executables for each env where jupyter is


### PR DESCRIPTION
I updated the _skip_env function so that it try to match the env name instead of the full path. The full path may cause some problem when it contains many layers of folders.