### PR TITLE
More customization

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -146,22 +146,33 @@ class CondaKernelSpecManager(KernelSpecManager):
         # We also add the root prefix into the soup
         root_prefix = join(self._conda_info["root_prefix"], jupyter)
         if exists(root_prefix):
+            # Replace root by root named kernel
+            root_exec = join(self._conda_info["root_prefix"], python)
+            for env in list(all_envs):
+                if all_envs[env]['executable'] == root_exec:
+                    all_envs.pop(env)
+                    break
+
             all_envs.update({
                 'conda-root-py': {
                     'display_name': self.name_format.format('Python', 'root'),
-                    'executable': join(self._conda_info["root_prefix"],
-                                       python),
+                    'executable': root_exec,
                     'language_key': 'py',
                 }
             })
-        # Use Jupyter's default kernel name ('python2' or 'python3') for
-        # current env
-        if exists(join(sys.prefix, jupyter)) and exists(join(sys.prefix,
-                                                             python)):
+        # Use Jupyter's default kernel name ('python2' or 'python3') for current env
+        if exists(join(sys.prefix, jupyter)) and exists(join(sys.prefix, python)):
+            # Replace default by default named kernel
+            default_exec = join(sys.prefix, python)
+            for env in list(all_envs):
+                if all_envs[env]['executable'] == default_exec:
+                    all_envs.pop(env)
+                    break
+
             all_envs.update({
                 NATIVE_KERNEL_NAME: {
                     'display_name': self.name_format.format('Python', 'default'),
-                    'executable': join(sys.prefix, python),
+                    'executable': default_exec,
                     'language_key': 'py',
                 }
             })

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -118,12 +118,14 @@ class CondaKernelSpecManager(KernelSpecManager):
         def get_paths_by_env(display_prefix, language_key, language_exe, envs):
             """ Get a dict with name_env:info for kernel executables
             """
+            whitelist = getattr(self, 'whitelist', set())
             language_envs = {}
             for base in envs:
                 exe_path = join(base, language_exe)
                 if exists(join(base, jupyter)) and exists(exe_path) and not self._skip_env(base):
                     env_name = split(base)[1]
                     name = 'conda-env-{}-{}'.format(env_name, language_key)
+                    if not whitelist or name in whitelist:
                     language_envs[name] = {
                         'display_name': self.name_format.format(display_prefix, env_name),
                         'executable': exe_path,
@@ -135,8 +137,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         all_envs = {}
 
         # Get the python envs
-        python_envs = get_paths_by_env("Python", "py", python,
-                                       self._conda_info["envs"])
+        python_envs = get_paths_by_env("Python", "py", python, self._conda_info["envs"])
         all_envs.update(python_envs)
 
         # Get the R envs

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -148,7 +148,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         if exists(root_prefix):
             all_envs.update({
                 'conda-root-py': {
-                    'display_name': 'Python [conda root]',
+                    'display_name': self.name_format.format('Python', 'root'),
                     'executable': join(self._conda_info["root_prefix"],
                                        python),
                     'language_key': 'py',
@@ -160,7 +160,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                                                              python)):
             all_envs.update({
                 NATIVE_KERNEL_NAME: {
-                    'display_name': 'Python [default]',
+                    'display_name': self.name_format.format('Python', 'default'),
                     'executable': join(sys.prefix, python),
                     'language_key': 'py',
                 }

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -26,6 +26,8 @@ class CondaKernelSpecManager(KernelSpecManager):
     """
     env_filter = Unicode(None, config=True, allow_none=True,
                          help="Do not list environment names that match this regex")
+    name_format = Unicode('{0} [conda env:{1}]', config=True, 
+                          help="String name format; '{{0}}' = Language, '{{1}}' = Kernel")
 
     def __init__(self, **kwargs):
         super(CondaKernelSpecManager, self).__init__(**kwargs)
@@ -123,8 +125,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                     env_name = split(base)[1]
                     name = 'conda-env-{}-{}'.format(env_name, language_key)
                     language_envs[name] = {
-                        'display_name': '{} [conda env:{}]'.format(
-                            display_prefix, env_name),
+                        'display_name': self.name_format.format(display_prefix, env_name),
                         'executable': exe_path,
                         'language_key': language_key,
                     }


### PR DESCRIPTION
This PR has the following changes:
- Display name customization through traitlet `name_format`
- Respect `KernelSpecManager.whitelist` (see https://jupyter-notebook.readthedocs.io/en/stable/config.html)
- Do not duplicate environment, root and default. If root is present, the corresponding environment is removed. And if default is root, root is removed.
- Switch to `subprocess.Popen` as `check_output` is not recommanded any more