### PR TITLE
Customize display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # nb_conda_kernels
+
 This extension enables a [Jupyter Notebook](http://jupyter.org)
 or [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/)
 application in one [conda](https://conda.io/docs/)
 environment to access kernels for Python, R, and other languages
 found in other environments. When a kernel from an external environment is selected, the kernel conda environment is
-automatically activated before the kernel is launched. 
+automatically activated before the kernel is launched.
 This allows you to utilize different versions of Python, R,
 and other languages from a single Jupyter installation.
 
-The package works by defining a custom `KernelSpecManager` that 
+The package works by defining a custom `KernelSpecManager` that
 scans the current set of `conda` environments for kernel
-specifications. It dynamically modifies each `KernelSpec` 
+specifications. It dynamically modifies each `KernelSpec`
 so that it can be properly run from the notebook environment.
 When you create a new notebook, these modified kernels
 will be made available in the selection list.
@@ -23,20 +24,26 @@ you run Jupyter Notebook or JupyterLab. This might be your base
 `conda` environment, but it need not be. For instance,
 if the environment `notebook_env` contains the `notebook`
 package, then you would run
+
 ```shell
 conda install -n notebook_env nb_conda_kernels
 ```
+
 Any _other_ environments you wish to access in your
 notebooks must have an appropriate kernel
 package installed. For instance, to access a Python
 environment, it must have the `ipykernel` package; e.g.
+
 ```shell
 conda install -n python_env ipykernel
 ```
+
 To utilize an R environment, it must have the `r-irkernel` package; e.g.
+
 ```shell
 conda install -n r_env r-irkernel
 ```
+
 For other languages, their [corresponding kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels)
 must be installed.
 
@@ -54,6 +61,12 @@ wider Jupyter ecosystem to take advantage of these external
 kernels. This package will require modification to
 function properly in this new system.
 
+## Configuration
+
+This package introduces two additional configuration options:
+
+- `env_filter`: Regex to filter environment path matching it. Default: `None` (i.e. no filter)
+- `name_format`: String name format; `'{0}'` = Language, `'{1}'` = Kernel. Default: `'{0} [conda env:{1}]'`
 
 ## Development
 
@@ -64,6 +77,7 @@ function properly in this new system.
    [PhantomJS](http://phantomjs.org) and
    [CasperJS](http://casperjs.org) are used for testing,
    so installation requires both `conda` and `npm`:
+
    ```shell
    conda create -n nb_conda_kernels python=YOUR_FAVORITE_PYTHON
    # Linux / Mac
@@ -77,6 +91,7 @@ function properly in this new system.
    ```
 
 3. Install the source package in development mode.
+
    ```shell
    python setup.py develop
    # Linux / Mac
@@ -89,6 +104,7 @@ function properly in this new system.
    tests assume the existence of `ipykernel` in the
    base/root conda environment, and at least one conda
    environment with the `R` kernel. For example:
+
    ```shell
    conda install -n root ipykernel
    conda create -n nbrtest r-irkernel
@@ -97,11 +113,14 @@ function properly in this new system.
 5. To run all of the tests, the Node environment must be
    activated. The easiest way to do this is to use our
    `npm` test command:
+
    ```shell
    npm run test
    ```
+
    If you prefer to skip the Node-based tests, you can run
    `nose` directly, skipping the `test_notebook` module:
+
    ```
    nosetests --exclude=test_notebook
    ```
@@ -109,30 +128,38 @@ function properly in this new system.
 ## Changelog
 
 ### 2.2.0
+
 - Perform full activation of kernel conda environments
 - Discover kernels from their kernel specs, enabling the use
   of kernels besides Python and R
 
 ### 2.1.1
+
 - move to a full conda-based approach to build and test
 - add support for conda 4.4 and later, which can remove `conda` from the PATH
 
 ### 2.1.0
+
 - add support for regex-based filtering of conda environments that should not appear in the list
 
 ### 2.0.0
+
 - change kernel naming scheme to leave default kernels in place
 
 ### 1.0.3
+
 - ignore build cleanup on windows due to poorly-behaved PhantomJS processes
 
 ### 1.0.2
+
 - use [Travis-CI](https://travis-ci.org/Anaconda-Platform/nb_conda_kernels) for continuous integration
 - use [Coveralls](https://coveralls.io/github/Anaconda-Platform/nb_conda_kernels) for code coverage
 - use a [conda-forge](https://github.com/conda-forge/nb_conda_kernels-feedstock) for cross-platform `conda` package building
 
 ### 1.0.1
+
 - minor build changes
 
 ### 1.0.0
+
 - update to notebook 4.2

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -154,11 +154,10 @@ class CondaKernelSpecManager(KernelSpecManager):
                         kernel_name = '{}-{}'.format(base_name, count + 2)
                         if kernel_name not in all_specs:
                             break
-                if env_name != 'root':
-                    display_prefix = spec['display_name']
-                    if display_prefix.startswith('Python'):
-                        display_prefix = 'Python'
-                    spec['display_name'] = self.name_format.format(display_prefix, basename(env_name))
+                display_prefix = spec['display_name']
+                if display_prefix.startswith('Python'):
+                    display_prefix = 'Python'
+                spec['display_name'] = self.name_format.format(display_prefix, basename(env_name))
                 spec['argv'] = ['python', '-m', 'nb_conda_kernels.runner',
                                 conda_prefix, env_path] + spec['argv']
                 spec['resource_dir'] = abspath(kernel_dir)

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -191,7 +191,7 @@ class CondaKernelSpecManager(KernelSpecManager):
             environments.
         """
         kspecs = super(CondaKernelSpecManager, self).find_kernel_specs()
-        self.log.info(kspecs)
+
         # add conda envs kernelspecs
         kspecs.update({name: spec.resource_dir
                        for name, spec

--- a/nb_conda_kernels/tests/js/test_notebook_root_py.js
+++ b/nb_conda_kernels/tests/js/test_notebook_root_py.js
@@ -2,7 +2,7 @@
 
 var kernel_prefix = 'conda-root-py',
   kernel_suffix = '',
-  kernel_label = 'Python [conda root]';
+  kernel_label = 'Python [conda env:root]';
 
 casper.notebook_test_kernel(kernel_prefix, kernel_suffix, function(){
   casper.screenshot.init("root-python-kernel");


### PR DESCRIPTION
Allow user to customize display name through configuration:

```json
  "CondaKernelSpecManager": {
    "name_format": "{0}-{1}"
  }
```
The argument *0* is the language and the *1* is the environment name.