### PR TITLE
Support spaces in environment names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,13 @@ install:
         source $HOME/miniconda/bin/activate;
     fi
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
-  # So we can get python-coveralls
-  - conda config --append channels conda-forge
   # The tests need to see the Python kernel in the root environment
-  - conda install conda-build ipykernel python-coveralls
+  - conda install conda-build ipykernel
   # The tests also need to see R and Python kernels in other environments.
   - conda create -n test_env1 r-irkernel r-base python=3
-  - conda create -n test_env2 ipykernel python=2
+  # Add a space to this environment to test proper quoting
+  - conda create -n 'test env2' ipykernel python=2
   - conda info -a
 
 script:
   - conda build conda-recipe --python=$PYTHON_VERSION
-
-after_success:
-  - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,8 @@ install:
     - conda install conda-build ipykernel
     # The tests also need to see R and Python kernels in other environments.
     - conda create -n test_env1 r-irkernel r-base python=3
-    - conda create -n test_env2 ipykernel python=2
+    # Add a space to this environment to test proper quoting
+    - conda create -n "test env2" ipykernel python=2
     - conda info -a
 
 # Skip .NET project specific build phase.

--- a/nb_conda_kernels/__main__.py
+++ b/nb_conda_kernels/__main__.py
@@ -1,0 +1,5 @@
+from jupyter_client import kernelspec
+from .manager import CondaKernelSpecManager
+kernelspec.KernelSpecManager = CondaKernelSpecManager
+from jupyter_client.kernelspecapp import KernelSpecApp
+KernelSpecApp.launch_instance()

--- a/nb_conda_kernels/runner.py
+++ b/nb_conda_kernels/runner.py
@@ -1,3 +1,4 @@
+import re
 import os
 import sys
 
@@ -19,7 +20,9 @@ def exec_in_env(conda_root, envname, command, *args):
             fullpath = None
     else:
         activate = os.path.join(conda_root, 'bin', 'activate')
-        ecomm = '. {} {} >/dev/null && printenv'.format(activate, envname)
+        activate = re.sub(r'([$"\\])', '\\\g<1>', activate)
+        envname = re.sub(r'([$"\\])', '\\\g<1>', envname)
+        ecomm = '. "{}" "{}" >/dev/null && printenv'.format(activate, envname)
         ecomm = ['bash', '-c', ecomm]
     env = check_output(ecomm, shell=is_win)
     encoding = sys.stdout.encoding or 'utf-8'

--- a/nb_conda_kernels/runner.py
+++ b/nb_conda_kernels/runner.py
@@ -10,7 +10,7 @@ def exec_in_env(conda_root, envname, command, *args):
     is_win = sys.platform.startswith('win')
     if is_win:
         activate = os.path.join(conda_root, 'Scripts', 'activate.bat')
-        ecomm = 'call {} {}>nul & set'.format(activate, envname)
+        ecomm = 'call "{}" "{}">nul & set'.format(activate, envname)
         if os.sep in command:
             fullpath = command
         else:


### PR DESCRIPTION
Also, easter egg: `python -m nb_conda_kernels list` does the equivalent of `jupyter kernelspec list`, only it uses our conda kernels. Even supports the `--json` option so we can see how that looks.