### PR TITLE
Upload packages to Anaconda Cloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ os:
   - osx
 
 env:
-  - PYTHON_VERSION=2.7
-  - PYTHON_VERSION=3.5
-  - PYTHON_VERSION=3.6
-  - PYTHON_VERSION=3.6 CONDA_SPEC='=4.3'
+  global:
+    - secure: "p7m2lBeihiUl6Bs6plrg0svucvqspD7ecX+7AhexlobPUIVEaAnHMqqoV86KrtKeQKi8wICkleOQ6qxUVtaHXX5h7VtqjPQNUpr4TgBhb8T6+z7WL895T2GKnza1TWnvXRdQAfMFaqQ7PsNQgpO/DaOSGaxG8LThMi4OLtJisuUk06+KXFnxBv83jqshEujjJtErD4WUnWWTvdVWKjTdBERHdHf4xxuss4DrDn4ILw+uWg7EWNigGtsPxSpZlKWh7ap5PKHkLCYUL9U+Ons++k0dZuxtdnBMRaeQ82/hOpOXbolvU35/cthmhQkQfhZInyjFQORCCucqvKGfftRtFi683kMxrYnbU5mXp2TUGIj9pX5zCWbH06kqXXYpM16F6w7bKWKYrXrB//pgD7sawh86cLCiIzKbYOvAnZWp++UTOyAKvmSEPSa+Kq+9JnN+CQ6xZf+NlqnB+0xM44vlkmDxphxm3dWkjsgKtdX27gAbGxw3AJ+8M0rlJ4Uo2jURBVeCtDDTmW4Yb5utPVCXWXnkWWr7yS1voGafSG80XevOGQMu47gP9/6yb4UF4/P7JYjU2FjrmLBCJWc/9fTYm+3k9ggSXzRWEO39iN0520xIsKQ5130cMT5siQbDPCXV7LFaew0r/b8o/7jInnKI8XocSjKSrqR5bWIlVRfGCNo="
+  matrix:
+    - PYTHON_VERSION=2.7
+    - PYTHON_VERSION=3.5
+    - PYTHON_VERSION=3.6
+    - PYTHON_VERSION=3.7
+    - PYTHON_VERSION=3.5 CONDA_SPEC='=4.3'
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -39,3 +43,15 @@ install:
 
 script:
   - conda build conda-recipe --python=$PYTHON_VERSION
+
+deploy:
+  - provider: script
+    on:
+      branch: master
+      tags: false
+    script:
+      - conda install anaconda-client
+      - if [ "$TRAVIS_TAG" == "" ]; then export ANACONDA_LABEL=dev; else export ANACONDA_LABEL=main; fi
+      - anaconda --token $ANACONDA_TOKEN upload $HOME/miniconda/conda-bld/*/*.tar.bz2 --user jupycon --label $ANACONDA_LABEL --force
+
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,18 @@ branches:
     - /\d+\.\d+.*/
 
 environment:
-  global:
-    PYTHONUNBUFFERED: 1
-    SAFETY_CHECKS: "--set safety_checks disabled"
+  PYTHONUNBUFFERED: 1
+  MINICONDA: C:\\Miniconda3-x64
+  SAFETY_CHECKS: --set safety_checks disabled
+  ANACONDA_TOKEN:
+    secure: EhvYaE20Lg9iN3fnkCdjkHWaa/ITU6eIYOui/RVW3+f9pj88ejLJ6USjFIGWDiSo
   matrix:
-    - MINICONDA: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.6"
-    - MINICONDA: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.5"
-    - MINICONDA: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "2.7"
-    - MINICONDA: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.5"
-      CONDA_SPEC: "=4.3"
+    - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: 2.7
+    - PYTHON_VERSION: 3.5
+      CONDA_SPEC: =4.3
       SAFETY_CHECKS: ""
 
 install:
@@ -30,7 +29,7 @@ install:
     # sort, we have other issues to deal with as well.
     - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no %SAFETY_CHECKS%
     # The tests expect to see the Python kernel in the root environment
-    - conda install conda-verify conda-build ipykernel
+    - conda install conda-verify conda-build ipykernel anaconda-client
     - if %ERRORLEVEL% neq 0 exit 1
     # We need to create additional environments to fully test the logic,
     # including an R kernel, a Python kernel, and environment names with
@@ -49,3 +48,10 @@ skip_branch_with_pr: true
 test_script:
     - conda build conda-recipe --python=%PYTHON_VERSION%
     - if %ERRORLEVEL% neq 0 exit 1
+
+deploy_script:
+    - if "%CONDA_SPEC%" == "=4.3" (exit 0)
+    - conda install anaconda-client
+    - if "%APPVEYOR_REPO_TAG%" == "true" (set ANACONDA_LABEL=main)
+    - if "%APPVEYOR_REPO_TAG%" == "false" (set ANACONDA_LABEL=dev)
+    - anaconda upload --token %ANACONDA_TOKEN% --user jupycon %MINICONDA%\conda-bld\*\*.tar.bz2 --label %ANACONDA_LABEL% --force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,18 @@
+# Build only the master branch, tagged commits, and pull requests
 branches:
   only:
     - master
     - /\d+\.\d+.*/
+# Don't run the (redundant) branch build with a pull request
+skip_branch_with_pr: true
 
 environment:
   PYTHONUNBUFFERED: 1
   MINICONDA: C:\\Miniconda3-x64
+  # Conda's safety checks verify that disk space and permissions are
+  # sufficient to complete the requested installation command. These
+  # are particularly slow on Windows and, in my view, not particularly
+  # valuable in a CI context.
   SAFETY_CHECKS: --set safety_checks disabled
   ANACONDA_TOKEN:
     secure: EhvYaE20Lg9iN3fnkCdjkHWaa/ITU6eIYOui/RVW3+f9pj88ejLJ6USjFIGWDiSo
@@ -14,6 +21,7 @@ environment:
     - PYTHON_VERSION: 3.6
     - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 2.7
+    # Conda 4.3 doesn't have the safety_checks config flag
     - PYTHON_VERSION: 3.5
       CONDA_SPEC: =4.3
       SAFETY_CHECKS: ""
@@ -23,10 +31,6 @@ install:
     # fixing the version of conda *before* doing the full activation.
     - call %MINICONDA%\Scripts\conda install conda%CONDA_SPEC% --yes
     - call %MINICONDA%\Scripts\activate.bat
-    # Safety checks, in my view, are not as useful in a CI context. They
-    # simply verify that the disk space and permissions are sufficient to
-    # execute the installation command. If we're having problems of that
-    # sort, we have other issues to deal with as well.
     - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no %SAFETY_CHECKS%
     # The tests expect to see the Python kernel in the root environment
     - conda install conda-verify conda-build ipykernel anaconda-client
@@ -43,15 +47,15 @@ install:
 
 # Skip .NET project specific build phase.
 build: off
-skip_branch_with_pr: true
 
 test_script:
     - conda build conda-recipe --python=%PYTHON_VERSION%
     - if %ERRORLEVEL% neq 0 exit 1
 
 deploy_script:
-    - if "%CONDA_SPEC%" == "=4.3" (exit 0)
+    - if not "%CONDA_SPEC%" == "" exit 0
+    - if not "%APPVEYOR_REPO_BRANCH%" == "master" exit 0
+    # Upload untagged builds to the dev label so they're not available to casual users
+    - if "%APPVEYOR_REPO_TAG%" == "false" set ANACONDA_LABEL=main
     - conda install anaconda-client
-    - if "%APPVEYOR_REPO_TAG%" == "true" (set ANACONDA_LABEL=main)
-    - if "%APPVEYOR_REPO_TAG%" == "false" (set ANACONDA_LABEL=dev)
-    - anaconda upload --token %ANACONDA_TOKEN% --user jupycon %MINICONDA%\conda-bld\*\*.tar.bz2 --label %ANACONDA_LABEL% --force
+    - anaconda --token %ANACONDA_TOKEN% upload %MINICONDA%\conda-bld\*\*.tar.bz2 --user jupycon --label %ANACONDA_LABEL% --force


### PR DESCRIPTION
The `jupycon` organization has been created to hold both development and tagged release builds of `nb_conda_kernels` and the other Jupyter/Conda packages.