### PR TITLE
Harden install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ This package introduces two additional configuration options:
 
    ```shell
    python setup.py develop
-   # Linux / Mac
-   python -m nb_conda_kernels.install --enable --prefix="${CONDA_PREFIX}"
-   # Windows
-   python -m nb_conda_kernels.install --enable --prefix="%CONDA_PREFIX%"
+   python -m nb_conda_kernels.install --enable
    ```
+
+   Note: there is no longer any need to supply a
+   `--prefix` argument to the installer.
 
 4. In order to properly exercise the package, the
    tests assume the existence of `ipykernel` in the

--- a/conda-recipe/post-link.bat
+++ b/conda-recipe/post-link.bat
@@ -1,4 +1,4 @@
 @echo off
 (
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable
 ) >>"%PREFIX%\.messages.txt" 2>&1

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -1,3 +1,3 @@
 {
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix="${PREFIX}"
+  "${PREFIX}/bin/python" -m nb_conda_kernels.install --enable
 } >>"$PREFIX/.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.bat
+++ b/conda-recipe/pre-unlink.bat
@@ -1,4 +1,4 @@
 @echo off
 (
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
+  "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable
 ) >>"%PREFIX%\.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -1,3 +1,3 @@
 {
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix="${PREFIX}"
+  "${PREFIX}/bin/python" -m nb_conda_kernels.install --disable
 } >>"$PREFIX/.messages.txt" 2>&1

--- a/nb_conda_kernels/install.py
+++ b/nb_conda_kernels/install.py
@@ -1,37 +1,45 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-# Copyright (c) - Continuum Analytics
-
 import argparse
-import os
-from os.path import exists, join
 import json
 import logging
+import os
+import sys
+
+from os.path import exists, join, abspath
 
 from traitlets.config.manager import BaseJSONConfigManager
-
-from jupyter_core.paths import jupyter_config_dir
+from traitlets.config.loader import JSONFileConfigLoader, ConfigFileNotFound
+from jupyter_core.paths import jupyter_config_dir, jupyter_config_path
 
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 log.setLevel(logging.INFO)
 
+
 # Arguments for command line
 parser = argparse.ArgumentParser(
-    description="Installs nbextension")
-parser.add_argument(
+    description="Installs the nb_conda_kernels notebook extension")
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument(
+    "-s", "--status",
+    help="Print the current status of nb_conda_kernels installation",
+    action="store_true")
+group.add_argument(
     "-e", "--enable",
     help="Automatically load nb_conda_kernels on notebook launch",
     action="store_true")
-parser.add_argument(
+group.add_argument(
     "-d", "--disable",
     help="Remove nb_conda_kernels from config on notebook launch",
     action="store_true")
-parser.add_argument(
+group2 = parser.add_mutually_exclusive_group(required=False)
+group2.add_argument(
     "-p", "--prefix",
-    help="prefix where to load nb_conda_kernels config",
+    help="Prefix where to load nb_conda_kernels config (default: sys.prefix)",
+    action="store")
+group2.add_argument(
+    "--path",
+    help="Absolute path to jupyter_notebook_config.json",
     action="store")
 parser.add_argument(
     "-v", "--verbose",
@@ -39,67 +47,124 @@ parser.add_argument(
     action="store_true"
 )
 
+
+NBA = "NotebookApp"
 CKSM = "nb_conda_kernels.CondaKernelSpecManager"
 KSMC = "kernel_spec_manager_class"
+JNC = "jupyter_notebook_config"
+ENDIS = ['disabled', 'enabled']
 
 
 def pretty(it):
     return json.dumps(it, indent=2)
 
 
-def install(enable=False, disable=False, prefix=None, verbose=False):
-    """Install the nb_conda_kernels config piece.
+def get_status(path, warn_if_mismatch=True):
+    all_paths = jupyter_config_path()
+    try:
+        cfg_all = JSONFileConfigLoader(JNC + '.json', path=all_paths).load_config()
+    except ConfigFileNotFound:
+        cfg_all = {}
+    log.debug("Global configuration:\n{}".format(pretty(cfg_all)))
+    is_enabled_all = cfg_all.get(NBA, {}).get(KSMC, None) == CKSM
+
+    cfg = BaseJSONConfigManager(config_dir=path).get(JNC)
+    log.debug("Local configuration ({}{}{}.json):\n{}".format(path, os.sep, JNC, pretty(cfg)))
+    is_enabled_local = cfg.get(NBA, {}).get(KSMC, None) == CKSM
+
+    if is_enabled_all != is_enabled_local and warn_if_mismatch:
+        mode_g = ENDIS[is_enabled_all].upper()
+        mode_l = ENDIS[is_enabled_local].upper()
+        log.warn('''WARNING: The global setting is overriding local settings:
+  Global setting: {}
+  Local setting: {}
+This can happen for several reasons:
+  - The --prefix argument does not point to sys.prefix
+  - The --path argument does not point to a directory
+    searched by this installation of Jupyter
+  - NotebookApp.kernel_spec_manager_class is set in
+    another directory on the configuration path'''.format(mode_g, mode_l))
+        if log.getEffectiveLevel() == logging.INFO:
+            log.warn("Use the --verbose flag for more information.")
+
+    return is_enabled_all, is_enabled_local
+
+
+def install(enable=False, disable=False, status=None, prefix=None, path=None, verbose=False):
+    """Installs the nb_conda_kernels configuration data.
 
     Parameters
     ----------
     enable: bool
-        Enable the nb_conda_kernels on every notebook launch
     disable: bool
-        Disable nb_conda_kernels on every notebook launch
+    status: bool
+        Enable/disable nb_conda_kernels on every notebook launch,
+        or simply check the status of installation, respectively.
+        Exactly one of these should be supplied.
+    prefix: None
+    path: None
+        The prefix of the Python environment where the Jupyter
+        configuration is to be found and/or created, or the full
+        path to jupyter_notebook_config.json, respecitvely. Exactly
+        one of these should be supplied. If prefix is supplied, it
+        is equivalent to path = join(prefix, 'etc', 'jupyter'). If
+        neither is supplied, jupyter_core.paths.jupyter_config_path()
+        will be searched for the first path within sys.prefix. If
+        there are none, the first path will be selected.
+    verbose: bool, default False
     """
     if verbose:
         log.setLevel(logging.DEBUG)
-
-    if enable == disable:
-        log.error("Please provide (one of) --enable or --disable")
-        raise ValueError(enable, disable)
-
-    log.info("{}abling nb_conda_kernels...".format("En" if enable else "Dis"))
-
-    path = jupyter_config_dir()
-
-    if prefix is not None:
-        path = join(prefix, "etc", "jupyter")
-        if not exists(path):
-            log.debug("Making directory {}...".format(path))
-            os.makedirs(path)
-
-    cm = BaseJSONConfigManager(config_dir=path)
-    cfg = cm.get("jupyter_notebook_config")
-
-    log.debug("Existing config in {}...\n{}".format(path, pretty(cfg)))
-
-    nb_app = cfg.setdefault("NotebookApp", {})
-
-    if enable:
-        nb_app.update({KSMC: CKSM})
-    elif disable and nb_app.get(KSMC, None) == CKSM:
-        nb_app.pop(KSMC)
-
-    log.debug("Writing config in {}...".format(path))
-
-    cm.set("jupyter_notebook_config", cfg)
-
-    cfg = cm.get("jupyter_notebook_config")
-
-    log.debug("Verifying config in {}...\n{}".format(path, pretty(cfg)))
-
-    if enable:
-        assert cfg["NotebookApp"][KSMC] == CKSM
+    if status:
+        log.info("Determining the status of nb_conda_kernels...")
     else:
-        assert KSMC not in cfg["NotebookApp"]
+        log.info("{}ing nb_conda_kernels...".format(ENDIS[enable][:-2].capitalize()))
 
-    log.info("{}abled nb_conda_kernels".format("En" if enable else "Dis"))
+    all_paths = jupyter_config_path()
+    if path or prefix:
+        if prefix:
+            path = join(prefix, "etc", "jupyter")
+        if path not in all_paths:
+            log.warn('WARNING: the prefix is not on the current jupyter config path')
+        path = abspath(path)
+    else:
+        prefix_s = sys.prefix + os.sep
+        for path in all_paths:
+            if path.startswith(prefix_s):
+                break
+        else:
+            log.warn('WARNING: no path within sys.prefix was found')
+            path = all_paths[0]
+    log.debug('Path: {}'.format(path))
+
+    is_enabled_all, is_enabled_local = get_status(path, not disable)
+
+    if status:
+        log.info('Status: {}'.format(ENDIS[is_enabled_all]))
+        return
+    elif is_enabled_all == enable:
+        log.info("Already {}, no change required".format(ENDIS[enable]))
+        return
+    elif is_enabled_local == enable:
+        log.info("No change required to local configuration")
+    else:
+        cm = BaseJSONConfigManager(config_dir=path)
+        cfg = cm.get(JNC)
+        if enable:
+            log.debug('Adding to local configuration')
+            cfg.setdefault(NBA, {})[KSMC] = CKSM
+        else:
+            log.debug('Removing from local configuration')
+            cfg[NBA].pop(KSMC)
+            if not cfg[NBA]:
+                cfg.pop(NBA)
+        log.debug("Writing config in {}...".format(path))
+        cm.set(JNC, cfg)
+
+    is_enabled_all, is_enabled_local = get_status(path, True)
+    if is_enabled_all != enable:
+        raise RuntimeError('Could not {} nb_conda_kernels'.format(ENDIS[enable][:-1]))
+    log.info("{} nb_conda_kernels".format(ENDIS[enable].capitalize()))
 
 
 if __name__ == '__main__':

--- a/nb_conda_kernels/tests/test_install.py
+++ b/nb_conda_kernels/tests/test_install.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+from subprocess import check_output, STDOUT
+
+STATUS = 'Determining the status of nb_conda_kernels...'
+ENABLING = 'Enabling nb_conda_kernels...'
+DISABLING = 'Disabling nb_conda_kernels...'
+IS_ENABLED = 'Status: enabled'
+IS_DISABLED = 'Status: disabled'
+
+if sys.platform.startswith('win'):
+    PYTHON = os.path.join(sys.prefix, 'python.exe')
+else:
+    PYTHON = os.path.join(sys.prefix, 'bin', 'python')
+
+
+def check_command_(command, out1, out2, verbose=False):
+    cmd = [PYTHON, '-m', 'nb_conda_kernels.install', '--' + command]
+    if verbose:
+        cmd.append('--verbose')
+    print('Testing: {}'.format(' '.join(cmd)))
+    output = check_output(cmd, stderr=STDOUT).decode()
+    print('\n'.join('| ' + x for x in output.splitlines()))
+    assert out1 in output
+    assert out2 in output
+
+
+def test_install():
+    for verbose in (False, True):
+        for test in (('status', STATUS, IS_ENABLED),
+                     ('disable', DISABLING, IS_DISABLED),
+                     ('status', STATUS, IS_DISABLED),
+                     ('enable', ENABLING, IS_ENABLED),
+                     ('status', STATUS, IS_ENABLED)):
+            check_command_(*test, verbose=verbose)
+
+
+if __name__ == '__main__':
+    test_install()


### PR DESCRIPTION
Installs into `sys.prefix` by default, generally making the need to supply a `--prefix` argument irrelevant. Also adds additional checks to make sure the enabling/disabling isn't thwarted by configurations outside of sys.prefix (e.g., `~/.jupyter`, `/etc/jupyter`)