### PR TITLE
enhance conda post-link and pre-unlink scripts

### DIFF
--- a/conda-recipe/post-link.bat
+++ b/conda-recipe/post-link.bat
@@ -1,4 +1,4 @@
 @echo off
 :: Set PATH explicitly as it may not be set correctly by some versions of conda
 set "PATH=%PATH%;%PREFIX%\Library\bin"
-"%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix %PREFIX% >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\python.exe" -m nb_conda_kernels.install --enable >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/conda-recipe/post-link.bat
+++ b/conda-recipe/post-link.bat
@@ -1,4 +1,4 @@
 @echo off
-(
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable
-) >>"%PREFIX%\.messages.txt" 2>&1
+:: Set PATH explicitly as it may not be set correctly by some versions of conda
+set "PATH=%PATH%;%PREFIX%\Library\bin"
+"%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix %PREFIX% >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix ${PREFIX} >>"${PREFIX}/.messages.txt" 2>&1
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --enable >>"${PREFIX}/.messages.txt" 2>&1

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -1,3 +1,1 @@
-{
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --enable
-} >>"$PREFIX/.messages.txt" 2>&1
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix ${PREFIX} >>"${PREFIX}/.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.bat
+++ b/conda-recipe/pre-unlink.bat
@@ -1,4 +1,4 @@
 @echo off
 :: Set PATH explicitly as it may not be set correctly by some versions of conda
 set "PATH=%PATH%;%PREFIX%\Library\bin"
-"%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix %PREFIX% >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\python.exe" -m nb_conda_kernels.install --disable >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/conda-recipe/pre-unlink.bat
+++ b/conda-recipe/pre-unlink.bat
@@ -1,4 +1,4 @@
 @echo off
-(
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable
-) >>"%PREFIX%\.messages.txt" 2>&1
+:: Set PATH explicitly as it may not be set correctly by some versions of conda
+set "PATH=%PATH%;%PREFIX%\Library\bin"
+"%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix %PREFIX% >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix ${PREFIX} >>"${PREFIX}/.messages.txt" 2>&1
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --disable >>"${PREFIX}/.messages.txt" 2>&1

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -1,3 +1,1 @@
-{
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --disable
-} >>"$PREFIX/.messages.txt" 2>&1
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix ${PREFIX} >>"${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
Explicitly Pass "--prefix", the default should be fine but it is safer to be
explicit.

Simplify the scripts by removing the block, they are un-needed for single line
commands.

In the windows scripts set the PATH explicitly as most versions of conda do not
set this prior to calling the script. See:
https://github.com/conda/conda/issues/7789