### PR TITLE
Remove space in test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
-    - PYTHON_VERSION=3.5 CONDA_SPEC='=4.3'
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -28,7 +27,6 @@ install:
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   # Fix the conda version before full activation
-  - $HOME/miniconda/bin/conda install conda$CONDA_SPEC --yes
   - source $HOME/miniconda/bin/activate
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
   # The tests need to see the Python kernel in the root environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ install:
   # including an R kernel, a Python kernel, and environment names with
   # at least one non-ASCII character and one space. Because AppVeyor is
   # difficult to work with for non-ASCII content we're using env files.
-  - conda env create -f conda-recipe/testenv1.yaml
-  - conda env create -f conda-recipe/testenv2.yaml
+  - conda env create -v -f conda-recipe/testenv1.yaml
+  - conda env create -v -f conda-recipe/testenv2.yaml
   - rm -f $HOME/.conda/environments.txt
   - conda info -a
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,13 @@ install:
     - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no %SAFETY_CHECKS%
     # The tests expect to see the Python kernel in the root environment
     # Apparent bug in conda-build 3.16.2 prevents tests from being run
-    - conda install conda-verify "conda-build<3.16" ipykernel anaconda-client
+    - conda install conda-verify conda-build ipykernel anaconda-client
     # We need to create additional environments to fully test the logic,
     # including an R kernel, a Python kernel, and environment names with
     # at least one non-ASCII character and one space. Because AppVeyor is
     # difficult to work with for non-ASCII content we're using env files.
-    - conda env create -f conda-recipe\testenv1.yaml
-    - conda env create -f conda-recipe\testenv2.yaml
+    - conda env create -v -f conda-recipe\testenv1.yaml
+    - conda env create -v -f conda-recipe\testenv2.yaml
     - conda info -a
 
 # Skip .NET project specific build phase.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ skip_branch_with_pr: true
 environment:
   PYTHONUNBUFFERED: 1
   MINICONDA: C:\\Miniconda3-x64
-  # Conda's safety checks verify that disk space and permissions are
-  # sufficient to complete the requested installation command. These
-  # are particularly slow on Windows and, in my view, not particularly
-  # valuable in a CI context.
-  SAFETY_CHECKS: --set safety_checks disabled
   ANACONDA_TOKEN:
     secure: J6mabXFRRZxAU+TjkDZv1Hh9/vZNbR6mmrV40amMMyDhXsRwcBMaiMDk2DGZo/6m
   matrix:
@@ -21,20 +16,11 @@ environment:
     - PYTHON_VERSION: 3.6
     - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 2.7
-    # Conda 4.3 doesn't have the safety_checks config flag
-    - PYTHON_VERSION: 3.5
-      CONDA_SPEC: =4.3
-      SAFETY_CHECKS: ""
 
 install:
-    # Because the specifics of activation need to be tested here, we are
-    # fixing the version of conda *before* doing the full activation.
     - mkdir C:\Users\appveyor\.conda
-    - call %MINICONDA%\Scripts\conda install conda%CONDA_SPEC% --yes
     - call %MINICONDA%\Scripts\activate.bat
-    - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no %SAFETY_CHECKS%
-    # The tests expect to see the Python kernel in the root environment
-    # Apparent bug in conda-build 3.16.2 prevents tests from being run
+    - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no  --set safety_checks disabled
     - conda install conda-verify conda-build ipykernel anaconda-client
     # We need to create additional environments to fully test the logic,
     # including an R kernel, a Python kernel, and environment names with

--- a/conda-recipe/testenv2.yaml
+++ b/conda-recipe/testenv2.yaml
@@ -1,4 +1,4 @@
-name: "t\u00c6st env2"
+name: "t\u00c6st_env2"
 dependencies:
   - ipykernel
   - python=3

--- a/nb_conda_kernels/tests/test_config.py
+++ b/nb_conda_kernels/tests/test_config.py
@@ -42,8 +42,6 @@ def test_configuration():
                     checks['env_py'] = True
                 if key.endswith('-r'):
                     checks['env_r'] = True
-            if ' ' in long_env:
-                checks['env_space'] = True
             try:
                 long_env.encode('ascii')
             except UnicodeEncodeError:
@@ -58,10 +56,9 @@ def test_configuration():
     print('  - Python kernel in other environment: {}'.format(bool(checks.get('env_py'))))
     print('  - R kernel in non-test environment: {}'.format(bool(checks.get('env_r'))))
     print('  - Environment with non-ASCII name: {}'.format(bool(checks.get('env_unicode'))))
-    print('  - Environment with space in name: {}'.format(bool(checks.get('env_space'))))
     # In some conda build scenarios, the test environment is not returned by conda
     # in the listing of conda environments.
-    assert len(checks) >= 7 - ('conda-bld' in prefix)
+    assert len(checks) >= 6 - ('conda-bld' in prefix)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Newer versions of conda have stopped allowing spaces in environment names. We were deliberately testing that case here so now our scripts are broken. For now let's declare victory and move on, by removing that test.