### PR TITLE
Add project name to kernel name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
   # The tests need to see the Python kernel in the root environment
   - conda install conda-verify conda-build ipykernel anaconda-client
   # We need to create additional environments to fully test the logic,
-  # including an R kernel, a Python kernel, and environment names with
-  # at least one non-ASCII character and one space. Because AppVeyor is
+  # including an R kernel, a Python kernel, and environment names with at
+  # least one non-ASCII character and one space. We also need one environment
+  # installed in a non-default environment location. Because AppVeyor is
   # difficult to work with for non-ASCII content we're using env files.
   - conda env create -f conda-recipe/testenv1.yaml -p $HOME/.conda/envs/test_env1
-  - conda env create -f conda-recipe/testenv1.yaml -p $HOME/test_env1
   - conda env create -f conda-recipe/testenv2.yaml
   - rm -f $HOME/.conda/environments.txt
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ install:
   # including an R kernel, a Python kernel, and environment names with
   # at least one non-ASCII character and one space. Because AppVeyor is
   # difficult to work with for non-ASCII content we're using env files.
-  - conda env create -f conda-recipe/testenv1.yaml
+  - conda env create -f conda-recipe/testenv1.yaml -p $HOME/.conda/envs/test_env1
+  - conda env create -f conda-recipe/testenv1.yaml -p $HOME/test_env1
   - conda env create -f conda-recipe/testenv2.yaml
   - rm -f $HOME/.conda/environments.txt
   - conda info -a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ install:
     # including an R kernel, a Python kernel, and environment names with
     # at least one non-ASCII character and one space. Because AppVeyor is
     # difficult to work with for non-ASCII content we're using env files.
-    - conda env create -f conda-recipe\testenv1.yaml
+    - conda env create -f conda-recipe\testenv1.yaml -p .conda\envs\test_env1
+    - conda env create -f conda-recipe\testenv1.yaml -p test_env1
     - conda env create -f conda-recipe\testenv2.yaml
     - conda info -a
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,11 +23,11 @@ install:
     - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no  --set safety_checks disabled
     - conda install conda-verify conda-build ipykernel anaconda-client
     # We need to create additional environments to fully test the logic,
-    # including an R kernel, a Python kernel, and environment names with
-    # at least one non-ASCII character and one space. Because AppVeyor is
+    # including an R kernel, a Python kernel, and environment names with at
+    # least one non-ASCII character and one space. We also need one environment
+    # installed in a non-default environment location. Because AppVeyor is
     # difficult to work with for non-ASCII content we're using env files.
-    - conda env create -f conda-recipe\testenv1.yaml -p .conda\envs\test_env1
-    - conda env create -f conda-recipe\testenv1.yaml -p test_env1
+    - conda env create -f conda-recipe\testenv1.yaml -p %HOME%\.conda\envs\test_env1
     - conda env create -f conda-recipe\testenv2.yaml
     - conda info -a
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - requests
     - mock
   commands:
+    - python -m nb_conda_kernels list # [py3k]
     - nosetests nb_conda_kernels
 
 about:

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -111,6 +111,8 @@ class CondaKernelSpecManager(KernelSpecManager):
         if base_prefix not in envs:
             envs.insert(0, base_prefix)
         envs_dirs = conda_info['envs_dirs']
+        if not envs_dirs:
+            envs_dirs = [join(base_prefix, 'envs')]
         all_envs = {}
         for env_path in envs:
             if self.env_filter is not None:
@@ -120,11 +122,25 @@ class CondaKernelSpecManager(KernelSpecManager):
                 env_name = 'root'
             else:
                 env_base, env_name = split(env_path)
-                # Do not include conda-bld environments
                 if env_base == build_prefix:
                     continue
-                if env_base not in envs_dirs or env_name in all_envs:
-                    env_name = env_path
+                if env_base != base_prefix or env_name in all_envs:
+                    # Add a prefix to environments not found in the default
+                    # environment location. We either use the name of the
+                    # parent directory, or the grandparent if the parent
+                    # has the name 'envs'. This handles scenarios like multiple
+                    # conda installations, anaconda-project instances, etc.
+                    env_base, project_name = split(env_base)
+                    if project_name == 'envs':
+                        project_name = basename(env_base)
+                    env_name = u'{}-{}'.format(project_name, env_name)
+            # Further disambiguate, if necessary, with a counter.
+            if env_name in all_envs:
+                base_name = env_name
+                for count in range(len(all_envs)):
+                    env_name = u'{}-{}'.format(base_name, count + 2)
+                    if env_name not in all_envs:
+                        break
             all_envs[env_name] = env_path
         return all_envs
 
@@ -166,21 +182,13 @@ class CondaKernelSpecManager(KernelSpecManager):
                 elif kernel_name == 'ir':
                     kernel_name = 'r'
                 kernel_prefix = '' if env_name == 'root' else 'env-'
-                kernel_name = u'conda-{}{}-{}'.format(
-                    kernel_prefix, basename(env_name), kernel_name)
+                kernel_name = u'conda-{}{}-{}'.format(kernel_prefix, env_name, kernel_name)
                 # Replace invalid characters with dashes
                 kernel_name = self.clean_kernel_name(kernel_name)
-                # Disambiguate if necessary
-                if kernel_name in all_specs:
-                    base_name = kernel_name
-                    for count in range(len(all_envs)):
-                        kernel_name = '{}-{}'.format(base_name, count + 2)
-                        if kernel_name not in all_specs:
-                            break
                 display_prefix = spec['display_name']
                 if display_prefix.startswith('Python'):
                     display_prefix = 'Python'
-                display_name = self.name_format.format(display_prefix, basename(env_name))
+                display_name = self.name_format.format(display_prefix, env_name)
                 if env_path == sys.prefix:
                     display_name += ' *'
                 spec['display_name'] = display_name

--- a/nb_conda_kernels/tests/test_config.py
+++ b/nb_conda_kernels/tests/test_config.py
@@ -38,6 +38,8 @@ def test_configuration():
             if key.startswith('conda-root-'):
                 checks['root_py'] = True
             if key.startswith('conda-env-'):
+                if len(key.split('-')) >= 5:
+                    checks['env_project'] = True
                 if key.endswith('-py'):
                     checks['env_py'] = True
                 if key.endswith('-r'):
@@ -56,9 +58,10 @@ def test_configuration():
     print('  - Python kernel in other environment: {}'.format(bool(checks.get('env_py'))))
     print('  - R kernel in non-test environment: {}'.format(bool(checks.get('env_r'))))
     print('  - Environment with non-ASCII name: {}'.format(bool(checks.get('env_unicode'))))
+    print('  - External project environment: {}'.format(bool(checks.get('env_project'))))
     # In some conda build scenarios, the test environment is not returned by conda
     # in the listing of conda environments.
-    assert len(checks) >= 6 - ('conda-bld' in prefix)
+    assert len(checks) >= 7 - ('conda-bld' in prefix)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch adds an extra identifier to any kernel name that lives in an environment outside of `$_CONDA_ROOT/envs`. For instance, if the environment is built within an Anaconda Project, this will be the project name. If the environment is built within an alternate conda installation, this will be the directory name of that installation.
