### PR TITLE
Improve the installation mechanism

### DIFF
--- a/nb_conda_kernels/install.py
+++ b/nb_conda_kernels/install.py
@@ -15,14 +15,27 @@ from jupyter_client import __version__ as jc_version
 log = logging.getLogger(__name__)
 
 
-NBA = "JupyterApp"
+JA = "JupyterApp"
+NBA = "NotebookApp"
 CKSM = "nb_conda_kernels.CondaKernelSpecManager"
+JKSM = "jupyter_client.kernelspec.KernelSpecManager"
 KSMC = "kernel_spec_manager_class"
-JNC = "jupyter_config"
-JNCJ = JNC + ".json"
 JCKP = "jupyter_client.kernel_providers"
 NCKDCKP = "nb_conda_kernels.discovery:CondaKernelProvider"
+JC = "jupyter_config"
+JNC = "jupyter_notebook_config"
 ENDIS = ['disabled', 'enabled']
+
+
+def shorten(path, prefix=True):
+    if prefix and path.startswith(sys.prefix + os.sep):
+        var = '%CONDA_PREFIX%' if sys.platform.startswith('win') else '$CONDA_PREFIX'
+        return var + path[len(sys.prefix):]
+    home = os.path.expanduser('~')
+    if path.startswith(home + os.sep):
+        var = '%USERPROFILE%' if sys.platform.startswith('win') else '~'
+        return var + path[len(home):]
+    return path
 
 
 def install(enable=False, disable=False, status=None, prefix=None, path=None, verbose=False):
@@ -65,6 +78,7 @@ def install(enable=False, disable=False, status=None, prefix=None, path=None, ve
         log.info("Determining the status of nb_conda_kernels...")
     else:
         log.info("{}ing nb_conda_kernels...".format(ENDIS[enable][:-2].capitalize()))
+    log.info("CONDA_PREFIX: {}".format(sys.prefix))
 
     is_enabled_entry = False
     # Disable the entry-point based mechanism. Most if this code will need
@@ -80,80 +94,108 @@ def install(enable=False, disable=False, status=None, prefix=None, path=None, ve
     if not is_enabled_entry and has_entrypoints:
         log.error(('NOTE: nb_conda_kernels is missing its entry point '
                    'for jupyter_client.kernel_providers, which is needed '
-                   'for correct operation with Jupyter 6.0.'))
+                   'for correct operation this version of Jupyter.'))
     if is_enabled_entry and not has_entrypoints:
         log.debug('  NOTE: entry points not used in Jupyter {}'.format(jc_version))
         is_enabled_entry = False
 
-    all_paths = jupyter_config_path()
+    all_paths = [abspath(p) for p in jupyter_config_path()]
+    default_path = join(sys.prefix, 'etc', 'jupyter')
+    search_paths = all_paths[::-1]
     if path or prefix:
         if prefix:
             path = join(prefix, 'etc', 'jupyter')
-        if path not in all_paths:
-            log.warn('WARNING: the requested path\n    {}\n'
-                     'is not on the Jupyter config path'.format(path))
+        path = abspath(path)
     else:
         prefix_s = sys.prefix + os.sep
-        for path in all_paths[::-1]:
+        for path in search_paths:
             if path.startswith(prefix_s):
                 break
         else:
-            log.warn('WARNING: no path within sys.prefix was found')
-
-    cfg = BaseJSONConfigManager(config_dir=path).get(JNC)
-    is_enabled_local = cfg.get(NBA, {}).get(KSMC, None) == CKSM
-
-    if not status and is_enabled_local != (enable and not is_enabled_entry):
-        if enable:
-            log.debug('Adding to local configuration')
-            cfg.setdefault(NBA, {})[KSMC] = CKSM
-        else:
-            log.debug('Removing from local configuration')
-            cfg[NBA].pop(KSMC)
-            if not cfg[NBA]:
-                cfg.pop(NBA)
-        log.debug("Writing config in {}...".format(path))
-        BaseJSONConfigManager(config_dir=path).set(JNC, cfg)
-        is_enabled_local = enable
-
-    # Retrieve the global configuration the same way that the Notebook
-    # app does: by looking through jupyter_notebook_config.json in
-    # every directory in jupyter_config_path(), in reverse order.
-    all_paths = jupyter_config_path()
-    log.debug('{} entries:'.format(JNCJ))
-    is_enabled_all = False
-    search_paths = all_paths[::-1]
+            path = default_path
+    if path != default_path or path not in all_paths:
+        log.info("Target path: {}".format(path))
     if path not in all_paths:
+        log.warning('WARNING: the configuration for the current environment\n'
+                    'is not affected by the target configuration path.')
         search_paths.append(path)
+
+    # Determine the effective configuration, and 
+    log.debug('Configuration files:')
+    fpaths = set()
+    is_enabled_all = {}
+    is_enabled_local = {}
     for path_g in search_paths:
-        cfg_g = BaseJSONConfigManager(config_dir=path_g).get(JNC)
         flag = '-' if path != path_g else ('*' if path in all_paths else 'x')
-        if exists(join(path_g, JNCJ)):
-            value =  '\n    '.join(json.dumps(cfg_g, indent=2).splitlines())
-            if NBA in cfg_g and KSMC in cfg_g[NBA]:
-                is_enabled_all = cfg_g[NBA][KSMC] == CKSM
+        value = ''
+        for fbase in (JC, JNC):
+            fpath = join(path_g, fbase + '.json')
+            cfg = BaseJSONConfigManager(config_dir=path_g).get(fbase)
+            dirty = False
+            for key in (JA, NBA):
+                spec = cfg.get(key, {}).get(KSMC)
+                if spec:
+                    if path_g in all_paths:
+                        is_enabled_all[key] = spec == CKSM
+                    if path_g == path:
+                        is_enabled_local[key] = spec == CKSM
+                    else:
+                        fpaths.add(join(path_g, fbase + '.json'))
+                if status or path_g != path:
+                    continue
+                if fbase == JNC or key == NBA or is_enabled_entry or disable:
+                    expected = None
+                else:
+                    expected = CKSM
+                if spec != expected:
+                    if expected is None:
+                        cfg[key].pop(KSMC)
+                        if not cfg[key]:
+                            cfg.pop(key)
+                    else:
+                        cfg.setdefault(key, {})[KSMC] = expected
+                    dirty = True
+            if dirty:
+                BaseJSONConfigManager(config_dir=path).set(fbase, cfg)
+            if dirty or exists(fpath):
+                value += '\n      ' + fbase + '.json'
+                if dirty:
+                    value += ' (MODIFIED)'
+                value += ': '
+                value += '\n        '.join(json.dumps(cfg, indent=2).splitlines())
+        log.debug('  {} {}: {}'.format(flag, shorten(path_g), value or '<no files>'))
+    is_enabled_all = bool(is_enabled_all.get(NBA, is_enabled_all.get(JA)))
+    is_enabled_local = bool(is_enabled_local.get(NBA, is_enabled_local.get(JA)))
+
+    if is_enabled_all != is_enabled_local or (is_enabled_entry and disable):
+        sev = 'WARNING' if status or path not in all_paths else 'ERROR'
+        if is_enabled_entry and disable:
+            msg = ['{}: the entrypoint mechanism cannot be disabled'.format(sev),
+                   'with changes to jupyter_config.json. To disable it,',
+                   'remove the nb_conda_kernels package.']
+            fpaths = []
+        elif path not in all_paths:
+            msg = fpaths = []
+        elif status:
+            msg = ['{}: the local configuration of nb_conda_kernels'.format(sev),
+                   'conflicts with the global configuration. Please examine']
         else:
-            value = '<no file>'
-        log.debug('  {} {}: {}'.format(flag, path_g, value))
+            what = ENDIS[is_enabled_local][:-1]
+            msg = ['{}: the attempt to {} nb_conda_kernels failed due to'.format(sev, what),
+                   'conflicts with global configuration files. Please examine']
+        if fpaths:
+            msg.append('the following file{} for potential conflicts:'
+                       .format('s' if len(fpaths) > 1 else ''))
+            for fpath in fpaths:
+                msg.append('    ' + shorten(fpath, False))
+            if not verbose:
+                msg.append('Use the --verbose flag for more information.')
+        if msg:
+            (log.warning if status else log.error)('\n'.join(msg))
 
-    if is_enabled_all != is_enabled_local:
-        logsev = log.warn if status else log.error
-        logstr = 'WARNING' if status else 'ERROR'
-        mode_g = ENDIS[is_enabled_all].upper()
-        mode_l = ENDIS[is_enabled_local].upper()
-        logsev(('{}: The global setting does not match the local setting:\n'
-                '    Global: {}\n'
-                '    Local:  {}\n'
-                'This is typically caused by another configuration file in\n'
-                'the path with a conflicting setting.').format(logstr, mode_g, mode_l))
-        if not verbose:
-            logsev("Use the --verbose flag for more information.")
-        if not status:
-            return 1
-
-    is_enabled_all = is_enabled_all or (has_entrypoints and is_enabled_entry)
+    is_enabled_all = is_enabled_all or is_enabled_entry
     log.info('Status: {}'.format(ENDIS[is_enabled_all]))
-    return 0
+    return 0 if status or is_enabled_all == is_enabled_local else 1
 
 
 if __name__ == '__main__':
@@ -183,7 +225,7 @@ if __name__ == '__main__':
         action="store")
     group2.add_argument(
         "--path",
-        help="Absolute path to jupyter_notebook_config.json",
+        help="Absolute path to the jupyter configuration directory",
         action="store")
     parser.add_argument(
         "-v", "--verbose",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,9 +3,6 @@ import sys
 
 from subprocess import check_output, call, STDOUT
 
-STATUS = 'Determining the status of nb_conda_kernels...'
-ENABLING = 'Enabling nb_conda_kernels...'
-DISABLING = 'Disabling nb_conda_kernels...'
 IS_ENABLED = 'Status: enabled'
 IS_DISABLED = 'Status: disabled'
 
@@ -15,7 +12,7 @@ else:
     PYTHON = os.path.join(sys.prefix, 'bin', 'python')
 
 
-def check_command_(command, out1, out2, verbose=False, quiet=False):
+def check_command_(command, out, verbose=False, quiet=False):
     cmd = [PYTHON, '-m', 'nb_conda_kernels.install', '--' + command]
     if verbose:
         cmd.append('--verbose')
@@ -23,18 +20,17 @@ def check_command_(command, out1, out2, verbose=False, quiet=False):
     output = check_output(cmd, stderr=STDOUT).decode()
     print('\n'.join('| ' + x for x in output.splitlines()))
     if not quiet:
-        assert out1 in output
-        assert out2 in output
+        assert out in output
 
 
 def test_install():
     call([PYTHON, '-m', 'nb_conda_kernels.install', '--enable'])
     for verbose in (False, True):
-        for test in (('status', STATUS, IS_ENABLED),
-                     ('disable', DISABLING, IS_DISABLED),
-                     ('status', STATUS, IS_DISABLED),
-                     ('enable', ENABLING, IS_ENABLED),
-                     ('status', STATUS, IS_ENABLED)):
+        for test in (('status',  IS_ENABLED),
+                     ('disable', IS_DISABLED),
+                     ('status',  IS_DISABLED),
+                     ('enable',  IS_ENABLED),
+                     ('status',  IS_ENABLED)):
             print(test)
             check_command_(*test, verbose=verbose, quiet=False)
 


### PR DESCRIPTION
Even though I cannot reproduce #158 I am concerned that our recent switch to using `JupyterApp` instead of `NotebookApp`, and `jupyter_config.json` instead of `jupyter_notebook_config.json`, might be leading to issues upon upgrade or uninstall/reinstall.

To that end I've modified the code for install to do a lot of cleanup when possible, and to better interpret the config landscape. In particular, it removes any extraneous configurations using the `NotebookApp` class or the older file location. And when looking at the effective status, it considers all of these potential values in the global configuration directories, too.