### PR TITLE
Use RUNNER_COMMAND for all exported kernelspecs

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -39,9 +39,9 @@ class CondaKernelSpecManager(KernelSpecManager):
         - ``--sys-prefix``: Install to Python's sys.prefix
         - ``PREFIX``: Specify an install prefix for the kernelspec. The kernel specs will be
         written in ``PREFIX/share/jupyter/kernels``. Be careful that the PREFIX
-        may not be discoverable by Jupyter; set JUPYTER_DATA_DIR to force it or run 
+        may not be discoverable by Jupyter; set JUPYTER_DATA_DIR to force it or run
         ``jupyter --paths`` to get the list of data directories.
-        
+
         If None, the conda kernel specs will only be available dynamically on notebook editors.
         """)
 
@@ -54,7 +54,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                     raise TraitError("CondaKernelSpecManager.kernelspec_path is not a directory.")
             self.log.debug("[nb_conda_kernels] Force conda_only=True as kernelspec_path is not None.")
             self.conda_only = True
-        
+
         return new_value
 
     name_format = Unicode('{0} [conda env:{1}]', config=True,
@@ -139,7 +139,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         envs = conda_info['envs']
         base_prefix = conda_info['conda_prefix']
         envs_prefix = join(base_prefix, 'envs')
-        build_prefix = join(base_prefix, 'conda-bld', '') 
+        build_prefix = join(base_prefix, 'conda-bld', '')
         # Older versions of conda do not seem to include the base prefix
         # in the environment list, but we do want to scan that
         if base_prefix not in envs:
@@ -238,7 +238,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                 })
                 spec['metadata'] = metadata
 
-                if self.kernelspec_path is not None:                    
+                if self.kernelspec_path is not None:
                     # Install the kernel spec
                     destination = self.install_kernel_spec(
                         kernel_dir,
@@ -248,14 +248,17 @@ class CondaKernelSpecManager(KernelSpecManager):
                     )
                     # Update the kernel spec
                     kernel_spec = join(destination, "kernel.json")
+                    tmp_spec = spec.copy()
+                    if env_path == sys.prefix:  # Add the conda runner to the installed kernel spec
+                        tmp_spec['argv'] = RUNNER_COMMAND + [conda_prefix, env_path] + spec['argv']
                     with open(kernel_spec, "w") as f:
-                        json.dump(spec, f)
-                
+                        json.dump(tmp_spec, f)
+
                 # resource_dir is not part of the spec file, so it is added at the latest time
                 spec['resource_dir'] = abspath(kernel_dir)
 
                 all_specs[kernel_name] = spec
-        
+
         # Remove non-existing conda environments
         if self.kernelspec_path is not None:
             kernels_destination = self._get_destination_dir(

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -240,19 +240,25 @@ class CondaKernelSpecManager(KernelSpecManager):
 
                 if self.kernelspec_path is not None:
                     # Install the kernel spec
-                    destination = self.install_kernel_spec(
-                        kernel_dir,
-                        kernel_name=kernel_name,
-                        user=self._kernel_user,
-                        prefix=self._kernel_prefix
-                    )
-                    # Update the kernel spec
-                    kernel_spec = join(destination, "kernel.json")
-                    tmp_spec = spec.copy()
-                    if env_path == sys.prefix:  # Add the conda runner to the installed kernel spec
-                        tmp_spec['argv'] = RUNNER_COMMAND + [conda_prefix, env_path] + spec['argv']
-                    with open(kernel_spec, "w") as f:
-                        json.dump(tmp_spec, f)
+                    try:
+                        destination = self.install_kernel_spec(
+                            kernel_dir,
+                            kernel_name=kernel_name,
+                            user=self._kernel_user,
+                            prefix=self._kernel_prefix
+                        )
+                        # Update the kernel spec
+                        kernel_spec = join(destination, "kernel.json")
+                        tmp_spec = spec.copy()
+                        if env_path == sys.prefix:  # Add the conda runner to the installed kernel spec
+                            tmp_spec['argv'] = RUNNER_COMMAND + [conda_prefix, env_path] + spec['argv']
+                        with open(kernel_spec, "w") as f:
+                            json.dump(tmp_spec, f)
+                    except OSError as error:
+                        self.log.warning(
+                            u"[nb_conda_kernels] Fail to install kernel '{}'.".format(kernel_dir),
+                            exc_info=error
+                        )
 
                 # resource_dir is not part of the spec file, so it is added at the latest time
                 spec['resource_dir'] = abspath(kernel_dir)

--- a/nb_conda_kernels/runner.py
+++ b/nb_conda_kernels/runner.py
@@ -10,21 +10,28 @@ except ImportError:
     from pipes import quote
 
 
-def exec_in_env(conda_root, envname, *command):
+def exec_in_env(conda_prefix, env_path, *command):
     # Run the standard conda activation script, and print the
     # resulting environment variables to stdout for reading.
+    is_current_env = env_path == sys.prefix
     if sys.platform.startswith('win'):
-        activate = os.path.join(conda_root, 'Scripts', 'activate.bat')
-        ecomm = [os.environ['COMSPEC'], '/S', '/U', '/C', '@echo', 'off', '&&',
-                 'chcp', '65001', '&&', 'call', activate, envname, '&&',
-                 '@echo', 'CONDA_PREFIX=%CONDA_PREFIX%', '&&',] + list(command)
-        subprocess.Popen(ecomm).wait()
+        if is_current_env:
+            subprocess.Popen(list(command)).wait()
+        else:
+            activate = os.path.join(conda_prefix, 'Scripts', 'activate.bat')
+            ecomm = [os.environ['COMSPEC'], '/S', '/U', '/C', '@echo', 'off', '&&',
+                    'chcp', '65001', '&&', 'call', activate, env_path, '&&',
+                    '@echo', 'CONDA_PREFIX=%CONDA_PREFIX%', '&&',] + list(command)
+            subprocess.Popen(ecomm).wait()
     else:
         command = ' '.join(quote(c) for c in command)
-        activate = os.path.join(conda_root, 'bin', 'activate')
-        ecomm = ". '{}' '{}' && echo CONDA_PREFIX=$CONDA_PREFIX && exec {}".format(activate, envname, command)
-        ecomm = ['sh' if 'bsd' in sys.platform else 'bash', '-c', ecomm]
-        os.execvp(ecomm[0], ecomm)
+        if is_current_env:
+            os.execvp(command[0], command)
+        else:
+            activate = os.path.join(conda_prefix, 'bin', 'activate')
+            ecomm = ". '{}' '{}' && echo CONDA_PREFIX=$CONDA_PREFIX && exec {}".format(activate, env_path, command)
+            ecomm = ['sh' if 'bsd' in sys.platform else 'bash', '-c', ecomm]
+            os.execvp(ecomm[0], ecomm)
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.manager import KernelManager
+
+from nb_conda_kernels.manager import CondaKernelSpecManager
+
+
+@pytest.fixture(scope="function")
+def jupyter_manager(tmp_path):
+    jupyter_data_dir = tmp_path / "share" / "jupyter"
+    jupyter_data_dir.mkdir(parents=True, exist_ok=True)
+    manager = CondaKernelSpecManager(kernelspec_path=str(tmp_path))
+    # Install the kernel specs
+    manager.find_kernel_specs()
+
+    return KernelSpecManager(kernel_dirs=[str(jupyter_data_dir / "kernels")])
+
+
+@pytest.fixture
+def jupyter_kernel(jupyter_manager, request):
+    return KernelManager(
+        kernel_spec_manager=jupyter_manager,
+        kernel_name=request.param,
+    )


### PR DESCRIPTION
Fixes #183

This add `RUNNER_COMMAND` to all exported kernelspecs. But it changes the runner to activate the environment only if it is not matching `sys.prefix`.

I added some unit tests for it - but bypass the unicode named kernel on Linux as it brought an error not related to `nb_conda_kernels` code.