### PR TITLE
Offer more option for displayed kernel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,15 @@ Possible values are:
   may not be discoverable by Jupyter; set JUPYTER_DATA_DIR to force it or run 
   `jupyter --paths` to get the list of data directories.
 
-- `name_format`: String name format; `'{0}'` = Language, `'{1}'` = Kernel. Default: `'{0} [conda env:{1}]'`
+- `name_format`: String name format  
+Default: `'{0} [conda env:{1}]'`  
+Available field names within the string:
+  - `{0}` = Language
+  - `{1}` = Environment name
+  - `{conda_kernel}` = Dynamically built kernel name for conda environment
+  - `{display_name}` = Kernel displayed name (as defined in the kernel spec)
+  - `{environment}`  = Environment name (identical to `{1}`)
+  - `{kernel}` = Original kernel name (name of the folder containing the kernel spec)
 
 In order to pass a configuration option in the command line use ```python -m nb_conda_kernels list --CondaKernelSpecManager.env_filter="regex"``` where regex is the regular expression for filtering envs "this|that|and|that" works.
 To set it in jupyter config file, edit the jupyter configuration file (py or json) located in your ```jupyter --config-dir```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Possible values are:
   `jupyter --paths` to get the list of data directories.
 
 - `name_format`: String name format  
-Default: `'{0} [conda env:{1}]'`  
+Default: `'{language} [conda env:{environment}]'`  
 Available field names within the string:
   - `{0}` = Language
   - `{1}` = Environment name
@@ -119,6 +119,7 @@ Available field names within the string:
   - `{display_name}` = Kernel displayed name (as defined in the kernel spec)
   - `{environment}`  = Environment name (identical to `{1}`)
   - `{kernel}` = Original kernel name (name of the folder containing the kernel spec)
+  - `{language}`  = Language (identical to `{0}`)
 
 In order to pass a configuration option in the command line use ```python -m nb_conda_kernels list --CondaKernelSpecManager.env_filter="regex"``` where regex is the regular expression for filtering envs "this|that|and|that" works.
 To set it in jupyter config file, edit the jupyter configuration file (py or json) located in your ```jupyter --config-dir```

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -58,7 +58,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         return new_value
 
     name_format = Unicode(
-        '{0} [conda env:{1}]',
+        '{language} [conda env:{environment}]',
         config=True,
         help="""String name format; available field names within the string:
         '{0}' = Language
@@ -67,6 +67,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         '{display_name}' = Kernel displayed name (as defined in the kernel spec)
         '{environment}'  = Environment name (identical to '{1}')
         '{kernel}' = Original kernel name (name of the folder containing the kernel spec)
+        '{language}'  = Language (identical to '{0}')
         """
     )
 
@@ -242,6 +243,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                     display_name=spec['display_name'],
                     environment=env_name,
                     kernel=raw_kernel_name,
+                    language=display_prefix,
                 )
                 if env_path == sys.prefix:
                     display_name += ' *'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,51 @@ def test_configuration():
     assert len(checks) >= 7
 
 
+@pytest.mark.parametrize("name_format, expected", [
+    ("{0} [conda env:{1}]", "Python [conda env:{env_name}]"),
+    (
+        "{0} {1} {conda_kernel} {display_name} {environment} {kernel}",
+        "Python {env_name} conda-env-{env_name}-xpython Python 3 (XPython) {env_name} xpython"
+    )
+])
+def test_kernel_name_format(monkeypatch, tmp_path, name_format, expected):
+    kernelspec = {
+        "display_name": "Python 3 (XPython)",
+        "argv": [
+            "@XPYTHON_KERNELSPEC_PATH@xpython",
+            "-f",
+            "{connection_file}"
+        ],
+        "language": "python",
+        "metadata": { "debugger": True }
+    }
+    mock_info = {
+        'conda_prefix': '/'
+    }
+    env_name = "dummy_env"
+    def envs(*args):
+        return {
+            env_name: str(tmp_path)
+        }
+
+    kernel_file = tmp_path / 'share' / 'jupyter' / 'kernels' / 'xpython' / 'kernel.json'
+    kernel_file.parent.mkdir(parents=True, exist_ok=True)
+    if sys.version_info >= (3, 0):
+        kernel_file.write_text(json.dumps(kernelspec))
+    else:
+        kernel_file.write_bytes(json.dumps(kernelspec))
+
+    monkeypatch.setattr(CondaKernelSpecManager, "_conda_info", mock_info)
+    monkeypatch.setattr(CondaKernelSpecManager, "_all_envs", envs)
+
+    manager = CondaKernelSpecManager(name_format=name_format)
+    specs = manager._all_specs()
+
+    assert len(specs) == 1
+    for spec in specs.values():
+        assert spec["display_name"] == expected.format(env_name=env_name)
+
+
 @pytest.mark.parametrize("kernelspec_path, user, prefix, expected", [
     (
         "",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,9 +92,10 @@ def test_configuration():
 
 @pytest.mark.parametrize("name_format, expected", [
     ("{0} [conda env:{1}]", "Python [conda env:{env_name}]"),
+    ("{language} [conda env:{environment}]", "Python [conda env:{env_name}]"),
     (
-        "{0} {1} {conda_kernel} {display_name} {environment} {kernel}",
-        "Python {env_name} conda-env-{env_name}-xpython Python 3 (XPython) {env_name} xpython"
+        "{0} {1} {conda_kernel} {display_name} {environment} {kernel} {language}",
+        "Python {env_name} conda-env-{env_name}-xpython Python 3 (XPython) {env_name} xpython Python"
     )
 ])
 def test_kernel_name_format(monkeypatch, tmp_path, name_format, expected):


### PR DESCRIPTION
# Problem

The naming options available does not allow to distinguish some kernels. In particular if you install `ipykernel` and `xpython` in the same conda environment, they will have identical _Language_ and _Environment name_.

# Proposed solution

This PR extends the field names available for `name_format` while ensuring backward compatibility and maintaining the default name.

`name_format`: String name format  
Default: `'{language} [conda env:{environment}]'`  
Available field names within the string:
  - `{0}` = Language
  - `{1}` = Environment name
  - `{conda_kernel}` = Dynamically built kernel name for conda environment
  - `{display_name}` = Kernel displayed name (as defined in the kernel spec)
  - `{environment}`  = Environment name (identical to `{1}`)
  - `{kernel}` = Original kernel name (name of the folder containing the kernel spec)
  - `{language}`  = Language (identical to `{0}`)