### PR TITLE
Zombie processes

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import glob
+import psutil
 
 import os
 from os.path import join, split, dirname, basename, abspath
@@ -137,6 +138,8 @@ class CondaKernelSpecManager(KernelSpecManager):
                                err)
             self._conda_info_cache = conda_info
             self._conda_info_cache_expiry = time.time() + CACHE_TIMEOUT
+
+        self.wait_for_child_processes_cleanup()
 
         return self._conda_info_cache
 
@@ -390,3 +393,11 @@ class CondaKernelSpecManager(KernelSpecManager):
         else:
             shutil.rmtree(spec_dir)
         return spec_dir
+
+    def wait_for_child_processes_cleanup(self):
+        p = psutil.Process()
+        for c in p.children():
+            try:
+                c.wait(timeout=0)
+            except psutil.TimeoutExpired:
+                pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ jupyter_client
 r-irkernel
 requests
 flake8
+psutil
 pytest
 pytest-cov
 mock

--- a/testbed/testenv1.yaml
+++ b/testbed/testenv1.yaml
@@ -3,4 +3,4 @@ dependencies:
   - backports.functools_lru_cache
   - r-irkernel
   - conda-forge::ipykernel
-  - python=2
+  - python=3

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,7 +11,6 @@ import pytest
 
 from nb_conda_kernels.discovery import CondaKernelProvider
 from nb_conda_kernels.manager import RUNNER_COMMAND
-from jupyter_client.blocking.client import Empty
 
 START_TIMEOUT = 10
 CMD_TIMEOUT = 3


### PR DESCRIPTION
When running conda info, the process spawns some child process and doesnt wait for them before exiting. This causes the child processes to reach an unreapable zombie state in some environments. Continued use means that these zombie process can accumulate quite quickly.

Includes a small fix to test, python2 no longer supported by ipykernel