### PR TITLE
revert to upload-artifact@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,8 @@ jobs:
         mv $CONDA_ROOT/conda-bld .
     - name: Upload the build artifact
       if: github.event_name == 'push'
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+      # Do not use v4 until merge behavior can be rebuilt
+      uses: actions/upload-artifact@v3
       with:
         # By uploading to the same artifact we can download all of the packages
         # and upload them all to anaconda.org in a single job


### PR DESCRIPTION
upload-artifact@v4 no longer supports the merge behavior that our GHA structure relies on. Until this can be fixed we must stick with v3