### PR TITLE
split windows/unix noarch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,50 +46,87 @@ jobs:
       if: steps.cache-key.outputs.cache-hit != 'true'
       # The argument tells the script we are in caching mode
       run: testbed/build.sh
-  tests:
+  build:
     runs-on: ${{ matrix.os }}
     needs: testbed
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,ubuntu-latest,windows-latest]
-        pyver: ["3.8","3.9","3.10","3.11"]
+        os: [ubuntu-latest,windows-latest]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         fetch-depth: 0
     - id: conda-root
-      name: Set CONDA_ROOT
+      name: Set CONDA_ROOT and artifact suffix
       run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then sfx=win; else sfx=unx; fi
+          echo "::set-output name=suffix::$sfx"
           CONDA_ROOT=$(dirname $GITHUB_WORKSPACE)/conda
           echo "::set-output name=value::$CONDA_ROOT"
           echo "CONDA_ROOT=$CONDA_ROOT" >> $GITHUB_ENV
+          echo "PACKAGE SUFFIX: $sfx"
           echo "CONDA_ROOT: $CONDA_ROOT"
     - name: Retrieve the testbed
       uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4
       with:
         path: ${{ steps.conda-root.outputs.value }}
         key: testbed-${{ matrix.os }}-${{ hashFiles('testbed') }}
-    - name: Verify or build the testbed
-      run: testbed/build.sh
-    - name: Build and test the package
+    - name: Build the package
+      id: build
       run: |
         source $CONDA_ROOT/etc/profile.d/conda.sh
-        [ "$RUNNER_OS" == "Windows" ] && export PYTHONIOENCODING=UTF-8
-        conda build conda-recipe --python=${{ matrix.pyver }} | tee build.log
-        # Because Windows refuses to preserve the error code
-        if grep ' FAILED ' build.log; then exit -1; fi
+        conda build --no-test conda-recipe
         mv $CONDA_ROOT/conda-bld .
     - name: Upload the build artifact
-      if: github.event_name == 'push'
-      # Do not use v4 until merge behavior can be rebuilt
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
-        # By uploading to the same artifact we can download all of the packages
-        # and upload them all to anaconda.org in a single job
-        name: package-${{ github.sha }}
+        name: package-${{ github.sha }}-${{ steps.conda-root.outputs.suffix }}
         path: conda-bld/*/*.tar.bz2
+  tests:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest,ubuntu-latest,windows-latest]
+        pyver: ["3.8","3.10","3.12"]
+    steps:
+    - name: Retrieve the source code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      with:
+        fetch-depth: 0
+    - id: conda-root
+      name: Set CONDA_ROOT and artifact suffix
+      run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then sfx=win; else sfx=unx; fi
+          echo "::set-output name=suffix::$sfx"
+          CONDA_ROOT=$(dirname $GITHUB_WORKSPACE)/conda
+          echo "::set-output name=value::$CONDA_ROOT"
+          echo "CONDA_ROOT=$CONDA_ROOT" >> $GITHUB_ENV
+          echo "PACKAGE SUFFIX: $sfx"
+          echo "CONDA_ROOT: $CONDA_ROOT"
+    - name: Retrieve the build artfiact
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      with:
+        name: package-${{ github.sha }}-${{ steps.conda-root.outputs.suffix }}
+        path: conda-bld
+    - name: Retrieve the testbed
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4
+      with:
+        path: ${{ steps.conda-root.outputs.value }}
+        key: testbed-${{ matrix.os }}-${{ hashFiles('testbed') }}
+    - name: Verify the testbed
+      run: testbed/build.sh
+    - name: Test the package
+      run: |
+        source $CONDA_ROOT/etc/profile.d/conda.sh
+        [ "$RUNNER_OS" = "Windows" ] && export PYTHONIOENCODING=UTF-8
+        export PYTHONUNBUFFERED=1
+        conda build --test conda-bld/noarch/*.tar.bz2 | tee build.log
+        # Because Windows refuses to preserve the error code
+        if grep ' FAILED ' build.log; then exit -1; fi
   upload:
     needs: tests
     runs-on: ubuntu-latest
@@ -99,11 +136,16 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         fetch-depth: 0
-    - name: Download the build artifacts
+    - name: Retrieve the windows artfiact
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
-        name: package-${{ github.sha }}
-        path: conda-bld
+        name: package-${{ github.sha }}-win
+        path: conda-bld-win
+    - name: Retrieve the unix artfiact
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      with:
+        name: package-${{ github.sha }}-unx
+        path: conda-bld-unx
     - name: Upload to anaconda.org
       env:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
@@ -111,7 +153,7 @@ jobs:
         source $CONDA/bin/activate
         conda install -y anaconda-client
         git describe --exact-match --tags HEAD || export LABEL="--label dev"
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user jupycon $LABEL conda-bld/*/*.tar.bz2 --force
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user jupycon $LABEL conda-bld-*/*/*.tar.bz2 --force
     - name: Clean up older artifacts
       uses: glassechidna/artifact-cleaner@master
       with:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,15 +9,20 @@ source:
 
 build:
   number: 0
+  noarch: python
 
 requirements:
   host:
     - python
+    - setuptools
+    - wheel
     - pip
   run:
-    - python
+    - python >=3.6
     - pywin32 # [win]
     - jupyter_client >=4.2
+    - __unix # [not win]
+    - __win # [win]
 
 test:
   source_files:
@@ -31,6 +36,7 @@ test:
     - requests
     - mock
   commands:
+    - pip check
     - python -m nb_conda_kernels list
     - python -m pytest -v --cov=nb_conda_kernels tests
 


### PR DESCRIPTION
Fixes #244 

The packages are built on unix and windows, but tested on windows, mac, and linux. Uses the same technique as @mathause used here: https://github.com/conda-forge/nb_conda_kernels-feedstock/pull/52

So we're actually testing the build framework that conda-forge is trying to move to.