### PR TITLE
properly handle case sensitivity; deduplicate

### DIFF
--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -458,7 +458,7 @@ class CondaKernelSpecManager(KernelSpecManager):
         return spec_dir
 
     def __del__(self):
-      t = self._conda_info_cache_thread
+      t = getattr(self, '_conda_info_cache_thread', None)
       # if there is a thread, wait for it to finish
       if t:
         t.join()

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -202,8 +202,8 @@ class CondaKernelSpecManager(KernelSpecManager):
             canonical environment names as keys, and full paths as values.
         """
         conda_info = self._conda_info
-        envs = conda_info['envs']
-        base_prefix = conda_info['conda_prefix']
+        envs = list(map(_canonicalize, conda_info['envs']))
+        base_prefix = _canonicalize(conda_info['conda_prefix'])
         envs_prefix = join(base_prefix, 'envs')
         build_prefix = join(base_prefix, 'conda-bld', '')
         # Older versions of conda do not seem to include the base prefix
@@ -269,7 +269,6 @@ class CondaKernelSpecManager(KernelSpecManager):
                     self.log.error("nb_conda_kernels | error loading %s:\n%s",
                                    spec_path, err)
                     continue
-                spec_path = _canonicalize(spec_path)
                 kernel_dir = dirname(spec_path)
                 kernel_name = raw_kernel_name = basename(kernel_dir)
                 if self.kernelspec_path is not None and kernel_name.startswith("conda-"):

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -21,8 +21,16 @@ CONDA_EXE = os.environ.get("CONDA_EXE", "conda")
 
 RUNNER_COMMAND = ['python', '-m', 'nb_conda_kernels.runner']
 
+_canonical_paths = {}
+
 
 def _canonicalize(path):
+    """
+    On case-sensitive filesystems, return the path unchanged.
+    On case-insensitive filesystems, cache the first value of
+    the path that we encounter, and return that for any other
+    case variation.
+    """
     def _inode(p):
         try:
             return os.stat(p).st_ino
@@ -34,7 +42,9 @@ def _canonicalize(path):
     if inode1 != inode2:
         return path
     inode3 = _inode(path.upper())
-    return plower if inode1 == inode3 else path
+    if inode3 != inode2:
+        return path
+    return _canonical_paths.setdefault(plower, path)
 
 
 class CondaKernelSpecManager(KernelSpecManager):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import json
 import os
 import sys
-from sys import prefix
 
 try:
     from unittest.mock import call, patch
@@ -12,7 +11,7 @@ except ImportError:
 
 import pytest
 from traitlets.config import Config, TraitError
-from nb_conda_kernels.manager import RUNNER_COMMAND, CondaKernelSpecManager
+from nb_conda_kernels.manager import RUNNER_COMMAND, CondaKernelSpecManager, _canonicalize
 
 # The testing regime for nb_conda_kernels is unique, in that it needs to
 # see an entire conda installation with multiple environments and both
@@ -36,13 +35,14 @@ def test_configuration():
     if conda_info is None:
         print('ERROR: Could not find conda find conda.')
         exit(-1)
-    print(u'Current prefix: {}'.format(prefix))
+    print(u'Current prefix: {}'.format(sys.prefix))
     print(u'Root prefix: {}'.format(conda_info['root_prefix']))
     print(u'Conda version: {}'.format(conda_info['conda_version']))
     print(u'Environments:')
     for env in conda_info['envs']:
         print(u'  - {}'.format(env))
     checks = {}
+    prefix = _canonicalize(sys.prefix)
     print('Kernels included in get_all_specs')
     print('---------------------------------')
     for key, value in spec_manager.get_all_specs().items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,7 +55,7 @@ def test_configuration():
         if key.startswith('conda-'):
             if long_env == prefix:
                 checks['env_current'] = True
-            if key.startswith('conda-root-'):
+            if key.startswith('conda-base-'):
                 checks['root_py'] = True
             if key.startswith('conda-env-'):
                 if len(key.split('-')) >= 5:
@@ -68,12 +68,9 @@ def test_configuration():
                 long_env.encode('ascii')
             except UnicodeEncodeError:
                 checks['env_unicode'] = True
-        elif key.lower().startswith('python'):
-            checks['default_py'] = True
     print('Scenarios required for proper testing')
     print('-------------------------------------')
-    print('  - Python kernel in test environment: {}'.format(bool(checks.get('default_py'))))
-    print('  - ... included in the conda kernel list: {}'.format(bool(checks.get('env_current'))))
+    print('  - Python kernel in test environment: {}'.format(bool(checks.get('env_current'))))
     print('  - Python kernel in root environment: {}'.format(bool(checks.get('root_py'))))
     print('  - Python kernel in other environment: {}'.format(bool(checks.get('env_py'))))
     print('  - R kernel in non-test environment: {}'.format(bool(checks.get('env_r'))))
@@ -87,7 +84,7 @@ def test_configuration():
     # on Windows works fine. So it is likely related to the way AppVeyor captures output
     if sys.platform.startswith('win'):
         checks.setdefault('env_unicode', False)
-    assert len(checks) >= 7
+    assert len(checks) >= 6
 
 
 @pytest.mark.parametrize("name_format, expected", [


### PR DESCRIPTION
Fixes #225
Fixes #218 

- Deduplicates the kernel set, preferring the nb_conda_kernels entry over the original.
- Properly handles case-sensitive filesystems now
- changed the term used to refer to the top-level environment from `root` to `base`, following modern conda standards. For users who are accustomed to the old use of `root`, I created a new configuration value `base_name`.