### PR TITLE
enable the debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Available field names within the string:
   - `{kernel}` = Original kernel name (name of the folder containing the kernel spec)
   - `{language}`  = Language (identical to `{0}`)
 
+- `enable_debugger`: Override kernelspec debugger metadata
+Default: None
+Possible values are:
+  - True: Override environment kernelspec metadata and set the debugger flag to `true`
+  - False: Override environment kernelspec metadata and set the debugger flag to `false`
+
 In order to pass a configuration option in the command line use ```python -m nb_conda_kernels list --CondaKernelSpecManager.env_filter="regex"``` where regex is the regular expression for filtering envs "this|that|and|that" works.
 To set it in jupyter config file, edit the jupyter configuration file (py or json) located in your ```jupyter --config-dir```
 - for `jupyter_config.py` - add a line "c.CondaKernelSpecManager.env_filter = 'regex'"

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -75,8 +75,9 @@ class CondaKernelSpecManager(KernelSpecManager):
 
         If None, the conda kernel specs will only be available dynamically on notebook editors.
         """)
-    enable_debugger = Bool(False, config=True,
-                           help="Set debugger=True in kernelspec metadata. The default is False.")
+    enable_debugger = Bool(None, config=True, allow_none=True,
+                           help="Optional: Override debugger setting in kernelspec metadata. "
+                           "If this parameter is unset it will default to the source kernel metadata.")
 
     @validate("kernelspec_path")
     def _validate_kernelspec_path(self, proposal):
@@ -316,8 +317,9 @@ class CondaKernelSpecManager(KernelSpecManager):
                 metadata.update({
                     'conda_env_name': env_name,
                     'conda_env_path': env_path,
-                    'debugger': self.enable_debugger
                 })
+                if self.enable_debugger is not None:
+                    metadata.update({"enable_debugger": self.enable_debugger})
                 spec['metadata'] = metadata
 
                 if self.kernelspec_path is not None:

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -319,7 +319,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                     'conda_env_path': env_path,
                 })
                 if self.enable_debugger is not None:
-                    metadata.update({"enable_debugger": self.enable_debugger})
+                    metadata.update({"debugger": self.enable_debugger})
                 spec['metadata'] = metadata
 
                 if self.kernelspec_path is not None:

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -75,6 +75,8 @@ class CondaKernelSpecManager(KernelSpecManager):
 
         If None, the conda kernel specs will only be available dynamically on notebook editors.
         """)
+    enable_debugger = Bool(False, config=True,
+                           help="Set debugger=True in kernelspec metadata. The default is False.")
 
     @validate("kernelspec_path")
     def _validate_kernelspec_path(self, proposal):
@@ -314,7 +316,7 @@ class CondaKernelSpecManager(KernelSpecManager):
                 metadata.update({
                     'conda_env_name': env_name,
                     'conda_env_path': env_path,
-                    'debugger': True
+                    'debugger': self.enable_debugger
                 })
                 spec['metadata'] = metadata
 

--- a/nb_conda_kernels/manager.py
+++ b/nb_conda_kernels/manager.py
@@ -313,7 +313,8 @@ class CondaKernelSpecManager(KernelSpecManager):
                 metadata = spec.get('metadata', {})
                 metadata.update({
                     'conda_env_name': env_name,
-                    'conda_env_path': env_path
+                    'conda_env_path': env_path,
+                    'debugger': True
                 })
                 spec['metadata'] = metadata
 


### PR DESCRIPTION
A new configuration parameter is added `enable_debugger`. If left off the debugger metadata value is taken from the source kernelspec in the conda environment. When set `enable_debugger` will override the value. This is was tested on jupyterlab 4 with a standard python (not xpython) kernel.