### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,8 @@ jobs:
       name: Set CONDA_ROOT
       run: |
           CONDA_ROOT=$(dirname $GITHUB_WORKSPACE)/conda
-          echo "::set-output name=value::$CONDA_ROOT"
+          echo "value=$CONDA_ROOT" >> $GITHUB_OUTPUT
           echo "CONDA_ROOT=$CONDA_ROOT" >> $GITHUB_ENV
-          echo "CONDA_ROOT: $CONDA_ROOT"
     # Use a smaller cache entry to enable a quicker exit if we
     # have already built the testbed. Any small file will do
     - id: cache-key
@@ -42,6 +41,12 @@ jobs:
       with:
         path: ${{ steps.conda-root.outputs.value }}
         key: testbed-${{ matrix.os }}-${{ hashFiles('testbed') }}
+    - name: Install Miniconda
+      uses: conda-incubator/setup-miniconda@v3
+      if: steps.cache-key.outputs.cache-hit != 'true'
+      with:
+        auto-activate-base: true
+        activate-environment: ""
     - name: Verify or build the testbed
       if: steps.cache-key.outputs.cache-hit != 'true'
       # The argument tells the script we are in caching mode

--- a/testbed/build.sh
+++ b/testbed/build.sh
@@ -34,6 +34,7 @@ source $CONDA_ROOT/etc/profile.d/conda.sh
 conda activate base
 
 if [ ! -f $CONDA_ROOT/.created ]; then
+    conda config --prepend channels conda-forge --system
     pip install -e .
     python -m nb_conda_kernels.install --enable
 


### PR DESCRIPTION
- Resolve a GitHub actions deprecation about output variables
- Use setup-miniconda to get a consistent base conda experience
- Use conda-forge for the testbed channels to get R packages on Mac OSX
